### PR TITLE
Implement SAVE / LOAD query

### DIFF
--- a/processor/build.sbt
+++ b/processor/build.sbt
@@ -31,7 +31,7 @@ libraryDependencies ++= Seq(
   "org.slf4j"                  %  "slf4j-api"              % "1.6.4",
   "org.slf4j"                  %  "slf4j-log4j12"          % "1.6.4",
   // Jubatus
-  "us.jubat"                   % "jubatus"                 % "0.7.1"
+  "us.jubat"                   % "jubatus"                 % "0.8.0"
             exclude("org.jboss.netty", "netty"),
   // jubatusonyarn
   "us.jubat"                   %% "jubatus-on-yarn-client"    % "1.1"

--- a/processor/src/main/scala/us/jubat/jubaql_server/processor/JubaQLAST.scala
+++ b/processor/src/main/scala/us/jubat/jubaql_server/processor/JubaQLAST.scala
@@ -75,3 +75,7 @@ case class CreateFeatureFunction(funcName: String, args: List[(String, String)],
 
 case class CreateTriggerFunction(funcName: String, args: List[(String, String)],
                                  lang: String, body: String) extends JubaQLAST
+
+case class SaveModel(modelName: String, modelPath: String, modelId: String) extends JubaQLAST
+
+case class LoadModel(modelName: String, modelPath: String, modelId: String) extends JubaQLAST

--- a/processor/src/main/scala/us/jubat/jubaql_server/processor/JubaQLParser.scala
+++ b/processor/src/main/scala/us/jubat/jubaql_server/processor/JubaQLParser.scala
@@ -111,6 +111,9 @@ class JubaQLParser extends SqlParser with LazyLogging {
   protected lazy val TIME = Keyword("TIME")
   protected lazy val TUPLES = Keyword("TUPLES")
   protected lazy val OVER = Keyword("OVER")
+  protected lazy val SAVE = Keyword("SAVE")
+  protected lazy val ID = Keyword("ID")
+  protected lazy val LOAD = Keyword("LOAD")
 
   override val lexical = new JubaQLLexical(reservedWords)
 
@@ -369,6 +372,30 @@ class JubaQLParser extends SqlParser with LazyLogging {
     }
   }
 
+  protected lazy val saveModel: Parser[JubaQLAST] = {
+    SAVE ~ MODEL ~> modelIdent ~ USING ~ stringLit ~ WITH ~ ID ~ "=" ~ ident ^^ {
+      case modelName ~ _ ~ modelPath ~ _ ~ _ ~ _ ~ modelId =>
+        modelPath match {
+          case "" =>
+            null
+          case _ =>
+            SaveModel(modelName, modelPath, modelId)
+        }
+    }
+  }
+
+  protected lazy val loadModel: Parser[JubaQLAST] = {
+    LOAD ~ MODEL ~> modelIdent ~ USING ~ stringLit ~ WITH ~ ID ~ "=" ~ ident ^^ {
+      case modelName ~ _ ~ modelPath ~ _ ~ _ ~ _ ~ modelId =>
+        modelPath match {
+          case "" =>
+            null
+          case _ =>
+            LoadModel(modelName, modelPath, modelId)
+        }
+    }
+  }
+
   protected lazy val jubaQLQuery: Parser[JubaQLAST] = {
     createDatasource |
       createModel |
@@ -385,7 +412,9 @@ class JubaQLParser extends SqlParser with LazyLogging {
       stopProcessing |
       createFunction |
       createFeatureFunction |
-      createTriggerFunction
+      createTriggerFunction |
+      saveModel |
+      loadModel
   }
 
   // note: apply cannot override incompatible type with parent class

--- a/processor/src/main/scala/us/jubat/jubaql_server/processor/JubaQLService.scala
+++ b/processor/src/main/scala/us/jubat/jubaql_server/processor/JubaQLService.scala
@@ -19,6 +19,7 @@ import java.net.InetAddress
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.concurrent.ConcurrentHashMap
+import collection.JavaConversions._
 
 import com.twitter.finagle.Service
 import com.twitter.util.{Future => TwFuture, Promise => TwPromise}
@@ -27,6 +28,7 @@ import io.netty.util.CharsetUtil
 import RunMode.{Production, Development}
 import us.jubat.jubaql_server.processor.json._
 import us.jubat.jubaql_server.processor.updater._
+import org.apache.hadoop.conf.Configuration
 import org.apache.spark.{SparkFiles, SparkContext}
 import org.apache.spark.SparkContext._
 import org.apache.spark.rdd.RDD
@@ -44,10 +46,11 @@ import org.jboss.netty.handler.codec.http._
 import org.json4s._
 import org.json4s.native.{JsonMethods, Serialization}
 import org.json4s.JsonDSL._
+import org.apache.commons.io._
 import sun.misc.Signal
 import us.jubat.anomaly.AnomalyClient
 import us.jubat.classifier.ClassifierClient
-import us.jubat.common.Datum
+import us.jubat.common.{Datum, ClientBase}
 import us.jubat.recommender.RecommenderClient
 import us.jubat.yarn.client.{JubatusYarnApplication, JubatusYarnApplicationStatus, Resource}
 import us.jubat.yarn.common.{LearningMachineType, Location}
@@ -1164,6 +1167,72 @@ class JubaQLService(sc: SparkContext, runMode: RunMode, checkpointDir: String)
             Left((400, msg))
         }
 
+      case SaveModel(modelName, modelPath, modelId) =>
+        models.get(modelName) match {
+          case Some((jubaApp, createModelStmt, machineType)) =>
+            val chkResult = runMode match {
+              case RunMode.Production(zookeeper) =>
+                modelPath.startsWith("hdfs://")
+              case RunMode.Development =>
+                modelPath.startsWith("file://")
+            }
+
+            if (chkResult) {
+              val juba = jubaApp.saveModel(new org.apache.hadoop.fs.Path(modelPath), modelId)
+              juba match {
+                case Failure(t) =>
+                  val msg = "SAVE MODEL failed: %s".format(t.getMessage())
+                  logger.error(msg, t)
+                  Left((500, msg))
+
+                case _ =>
+                  Right(StatementProcessed("SAVE MODEL"))
+              }
+            } else {
+              val msg = "invalid model path (%s)".format(modelPath)
+              logger.warn(msg)
+              Left((400, msg))
+            }
+
+          case None =>
+            val msg = "model '%s' does not exist".format(modelName)
+            logger.warn(msg)
+            Left((400, msg))
+        }
+
+      case LoadModel(modelName, modelPath, modelId) =>
+        models.get(modelName) match {
+          case Some((jubaApp, createModelStmt, machineType)) =>
+            val chkResult = runMode match {
+              case RunMode.Production(zookeeper) =>
+                modelPath.startsWith("hdfs://")
+              case RunMode.Development =>
+                modelPath.startsWith("file://")
+            }
+
+            if (chkResult) {
+              val juba = jubaApp.loadModel(new org.apache.hadoop.fs.Path(modelPath), modelId)
+              juba match {
+                case Failure(t) =>
+                  val msg = s"LOAD MODEL failed: ${t.getMessage}"
+                  logger.error(msg, t)
+                  Left((500, msg))
+
+                case _ =>
+                  Right(StatementProcessed("LOAD MODEL"))
+              }
+            } else {
+              val msg = s"invalid model path ($modelPath)"
+              logger.warn(msg)
+              Left((400, msg))
+            }
+
+          case None =>
+            val msg = s"model '$modelName' does not exist"
+            logger.warn(msg)
+            Left((400, msg))
+        }
+
       case other =>
         val msg = "no handler for " + other
         logger.error(msg)
@@ -1511,8 +1580,8 @@ object LocalJubatusApplication extends LazyLogging {
           namedPipeWriter.close()
         }
 
-        new LocalJubatusApplication(jubatusProcess, aLearningMachineName, jubaCmdName,
-          rpcPort)
+        new LocalJubatusApplication(jubatusProcess, aLearningMachineName, aLearningMachineType,
+            jubaCmdName, rpcPort)
       } finally {
         namedPipe.delete()
       }
@@ -1566,8 +1635,11 @@ object LocalJubatusApplication extends LazyLogging {
 }
 
 // LocalJubatusApplication is not a JubatusYarnApplication, but extends JubatusYarnApplication for implementation.
-class LocalJubatusApplication(jubatus: Process, name: String, jubaCmdName: String, port: Int = 9199)
+class LocalJubatusApplication(jubatus: Process, name: String, aLearningMachineType: LearningMachineType, jubaCmdName: String, port: Int = 9199)
   extends JubatusYarnApplication(Location(InetAddress.getLocalHost, port), List(), null) {
+
+  private val timeoutCount: Int = 180
+  private val fileRe = """file://(.+)""".r
 
   override def status: JubatusYarnApplicationStatus = {
     throw new NotImplementedError("status is not implemented")
@@ -1585,10 +1657,126 @@ class LocalJubatusApplication(jubatus: Process, name: String, jubaCmdName: Strin
   }
 
   override def loadModel(aModelPathPrefix: org.apache.hadoop.fs.Path, aModelId: String): Try[JubatusYarnApplication] = Try {
-    throw new NotImplementedError("loadModel is not implemented")
+    logger.info(s"loadModel path: $aModelPathPrefix, modelId: $aModelId")
+
+    val strHost = jubatusProxy.hostAddress
+    val strPort = jubatusProxy.port
+
+    val srcDir = aModelPathPrefix.toUri().toString() match {
+      case fileRe(filepath) =>
+        val realpath = if (filepath.startsWith("/")) {
+          filepath
+        } else {
+          (new java.io.File(".")).getAbsolutePath + "/" + filepath
+        }
+        "file://" + realpath
+    }
+    logger.debug(s"convert srcDir: $srcDir")
+
+    val localFileSystem = org.apache.hadoop.fs.FileSystem.getLocal(new Configuration())
+    val srcDirectory = localFileSystem.pathToFile(new org.apache.hadoop.fs.Path(srcDir))
+    val srcPath = new java.io.File(srcDirectory, aModelId)
+    if (!srcPath.exists()) {
+      val msg = s"model path does not exist ($srcPath)"
+      logger.error(msg)
+      throw new RuntimeException(msg)
+    }
+
+    val srcFile = new java.io.File(srcPath, "0.jubatus")
+    if (!srcFile.exists()) {
+      val msg = s"model file does not exist ($srcFile)"
+      logger.error(msg)
+      throw new RuntimeException(msg)
+    }
+
+    val client: ClientBase = aLearningMachineType match {
+      case LearningMachineType.Anomaly =>
+        new AnomalyClient(strHost, strPort, name, timeoutCount)
+
+      case LearningMachineType.Classifier =>
+        new ClassifierClient(strHost, strPort, name, timeoutCount)
+
+      case LearningMachineType.Recommender =>
+        new RecommenderClient(strHost, strPort, name, timeoutCount)
+    }
+
+    val stsMap: java.util.Map[String, java.util.Map[String, String]] = client.getStatus()
+    val baseDir = localFileSystem.pathToFile(new org.apache.hadoop.fs.Path(stsMap.get(s"${strHost}_${strPort}").get("datadir")))
+    val mType = stsMap.get(s"${strHost}_${strPort}").get("type")
+    val dstFile = new java.io.File(baseDir, s"${strHost}_${strPort}_${mType}_${aModelId}.jubatus")
+
+    logger.debug(s"srcFile: $srcFile")
+    logger.debug(s"dstFile: $dstFile")
+
+    FileUtils.copyFile(srcFile, dstFile, false)
+
+    val ret = client.load(aModelId)
+    if (!ret) {
+      val msg = "load RPC failed"
+      logger.error(msg)
+      throw new RuntimeException(msg)
+    }
+    this
   }
 
   override def saveModel(aModelPathPrefix: org.apache.hadoop.fs.Path, aModelId: String): Try[JubatusYarnApplication] = Try {
-    throw new NotImplementedError("saveModel is not implemented")
+    logger.info(s"saveModel path: $aModelPathPrefix, modelId: $aModelId")
+
+    val strHost = jubatusProxy.hostAddress
+    val strPort = jubatusProxy.port
+
+    val strId = Math.abs(new Random().nextInt()).toString()
+
+    val result: Map[String, String] = aLearningMachineType match {
+      case LearningMachineType.Anomaly =>
+        val anomaly = new AnomalyClient(strHost, strPort, name, timeoutCount)
+        anomaly.save(strId)
+
+      case LearningMachineType.Classifier =>
+        val classifier = new ClassifierClient(strHost, strPort, name, timeoutCount)
+        classifier.save(strId)
+
+      case LearningMachineType.Recommender =>
+        val recommender = new RecommenderClient(strHost, strPort, name, timeoutCount)
+        recommender.save(strId)
+    }
+
+    logger.debug(s"save method result: $result")
+    if (result.size != 1) {
+      val msg = s"save RPC failed (got ${result.size} results)"
+      logger.error(msg)
+      throw new RuntimeException(msg)
+    }
+
+    val strSavePath = result.values.head
+    logger.debug(s"srcFile: $strSavePath")
+
+    val dstDir = aModelPathPrefix.toUri().toString() match {
+      case fileRe(filepath) =>
+        val realpath = if (filepath.startsWith("/")) {
+          filepath
+        } else {
+          (new java.io.File(".")).getAbsolutePath + "/" + filepath
+        }
+        "file://" + realpath
+    }
+    logger.debug(s"convert dstDir: $dstDir")
+
+    val localFileSystem = org.apache.hadoop.fs.FileSystem.getLocal(new Configuration())
+    val dstDirectory = localFileSystem.pathToFile(new org.apache.hadoop.fs.Path(dstDir))
+    val dstPath = new java.io.File(dstDirectory, aModelId)
+    val dstFile = new java.io.File(dstPath, "0.jubatus")
+    logger.debug(s"dstFile: $dstFile")
+
+    if (!dstPath.exists()) {
+      dstPath.mkdirs()
+    } else {
+      if (dstFile.exists()) {
+        dstFile.delete()
+      }
+    }
+
+    FileUtils.moveFile(new java.io.File(strSavePath), dstFile)
+    this
   }
 }


### PR DESCRIPTION
This PR implements SAVE / LOAD query to JubaQL system.

The syntax is as follows:

```
SAVE MODEL model_name USING path WITH ID = id
LOAD MODEL model_name USING path WITH ID = id
```

For example, in development mode,

```
SAVE MODEL test USING "file:///home/data/models" WITH ID = test001
LOAD MODEL test USING "file:///home/data/models" WITH ID = test001
```

will save a model file to / load a model file from `/home/data/models/test001/0.jubatus`.
You need to use hdfs:/// instead of file:/// for production mode.

Notes:
- This patch updates the required Jubatus client library version to 0.8.0 to use new save RPC that returns a path to the model file.
- This patch depends on https://github.com/jubatus/jubatus-on-yarn/pull/8.
- Documentation needs to be added once this patch got merged.
