### PR TITLE
(WIP) Persist sessions to ZooKeeper

### DIFF
--- a/gateway/build.sbt
+++ b/gateway/build.sbt
@@ -20,8 +20,14 @@ libraryDependencies ++= Seq(
   "net.databinder.dispatch"    %% "dispatch-core"  % "0.11.2",
   // parsing of program arguments
   "com.github.scopt"           %% "scopt"          % "3.2.0",
+  // apache curator
+  "org.apache.curator" % "apache-curator" % "2.8.0",
+  "org.apache.curator" % "curator-framework" % "2.8.0",
+  "org.apache.curator" % "curator-recipes" % "2.8.0",
   // testing
-  "org.scalatest"     %% "scalatest"               % "2.2.1"
+  "org.scalatest"     %% "scalatest"               % "2.2.1",
+  "org.apache.curator" % "curator-test" % "2.8.0",
+  "org.scala-lang.modules" %% "scala-async" % "0.9.2"
 )
 
 // disable parallel test execution to avoid BindException when mocking

--- a/gateway/src/main/resources/log4j.xml
+++ b/gateway/src/main/resources/log4j.xml
@@ -16,7 +16,12 @@
     <logger name="com.ning">
         <level value="info"/>
     </logger>
-
+    <logger name="org.apache.zookeeper">
+        <level value="error"/>
+    </logger>
+    <logger name="org.apache.curator">
+        <level value="error"/>
+    </logger>
     <root>
         <priority value="debug"/>
         <appender-ref ref="console"/>

--- a/gateway/src/main/scala/us/jubat/jubaql_server/gateway/GatewayPlan.scala
+++ b/gateway/src/main/scala/us/jubat/jubaql_server/gateway/GatewayPlan.scala
@@ -24,7 +24,6 @@ import us.jubat.jubaql_server.gateway.json.{Unregister, Register, Query, Session
 import scala.collection.mutable
 import org.json4s.DefaultFormats
 import org.json4s.native.Serialization.write
-import scala.util.Random
 import scala.util.{Try, Success, Failure}
 import java.io._
 import dispatch._
@@ -40,7 +39,7 @@ import java.nio.file.{StandardCopyOption, Files}
 class GatewayPlan(ipAddress: String, port: Int,
                   envpForProcessor: Array[String], runMode: RunMode,
                   sparkDistribution: String, fatjar: String,
-                  checkpointDir: String)
+                  checkpointDir: String, gatewayId: String, persistSession: Boolean)
   extends cycle.Plan
   /* With cycle.SynchronousExecution, there is a group of N (16?) threads
      (named "nioEventLoopGroup-5-*") that will process N requests in
@@ -64,10 +63,18 @@ class GatewayPlan(ipAddress: String, port: Int,
   with LazyLogging {
   lazy val underlying = new MemoryAwareThreadPoolExecutor(16, 65536, 1048576)
 
-  // holds session ids mapping to keys and host:port locations, respectively
-  val session2key: mutable.Map[String, String] = new mutable.HashMap()
-  val key2session: mutable.Map[String, String] = new mutable.HashMap()
-  val session2loc: mutable.Map[String, (String, Int)] = new mutable.HashMap()
+  // SessionManager: holds session ids mapping to keys and host:port locations, respectively
+  val sessionManager = try {
+    persistSession match {
+      case true => new SessionManager(gatewayId, new ZookeeperStore)
+      case false => new SessionManager(gatewayId)
+    }
+  } catch {
+    case e: Throwable => {
+      logger.error("failed to start session manager", e)
+      throw e
+    }
+  }
 
   /* When starting the processor using spark-submit, we rely on a certain
    * logging behavior. It seems like the log4j.xml file bundled with
@@ -97,113 +104,131 @@ class GatewayPlan(ipAddress: String, port: Int,
 
   def intent = {
     case req@POST(Path("/login")) =>
-      var sessionId = ""
-      var key = ""
+      val body = readAllFromReader(req.reader)
       val reqSource = req.remoteAddr
-      logger.info(f"received HTTP request at /login from $reqSource%s")
-      session2key.synchronized {
-        do {
-          sessionId = Alphanumeric.generate(20) // TODO: generate in a more sophisticated way.
-        } while (session2key.get(sessionId) != None)
-        do {
-          key = Alphanumeric.generate(20) // TODO: generate in a more sophisticated way.
-        } while (key2session.get(key) != None)
-        session2key += (sessionId -> key)
-        key2session += (key -> sessionId)
-      }
-      val callbackUrl = composeCallbackUrl(ipAddress, port, key)
-      val gatewayAddress = s"$ipAddress:$port"
+      logger.debug(f"received HTTP request at /login from $reqSource%s with body: $body%s")
 
-      val runtime = Runtime.getRuntime
-      val cmd = mutable.ArrayBuffer(f"$sparkDistribution%s/bin/spark-submit",
-                                    "--class", "us.jubat.jubaql_server.processor.JubaQLProcessor",
-                                    "--master", "", // set later
-                                    "--conf", "", // set later
-                                    "--conf", s"log4j.configuration=file:$tmpLog4jPath",
-                                    "--name", s"JubaQLProcessor:$gatewayAddress:$sessionId",
-                                    fatjar,
-                                    callbackUrl)
-      logger.info(f"starting Spark in run mode $runMode%s (session_id: $sessionId%s)")
-      val divide = runMode match {
-        case RunMode.Production(zookeeper, numExecutors, coresPerExecutor, sparkJar) =>
-          cmd.update(4, "yarn-cluster") // --master
-          // When we run the processor on YARN, any options passed in with run.mode
-          // will be passed to the SparkSubmit class, not the the Spark driver. To
-          // get the run.mode passed one step further, we use the extraJavaOptions
-          // variable. It is important to NOT ADD ANY QUOTES HERE or they will be
-          // double-escaped on their way to the Spark driver and probably never end
-          // up there.
-          cmd.update(6, "spark.driver.extraJavaOptions=-Drun.mode=production " +
-            s"-Djubaql.zookeeper=$zookeeper " +
-            s"-Djubaql.checkpointdir=$checkpointDir "+
-            s"-Djubaql.gateway.address=$gatewayAddress " +
-            s"-Djubaql.processor.sessionId=$sessionId") // --conf
-          // also specify the location of the Spark jar file, if given
-          val sparkJarParams = sparkJar match {
-            case Some(url) => "--conf" :: s"spark.yarn.jar=$url" :: Nil
-            case _ => Nil
-          }
-          cmd.insertAll(9, "--num-executors" :: numExecutors.toString ::
-            "--executor-cores" :: coresPerExecutor.toString :: sparkJarParams)
-          logger.debug("executing: " + cmd.mkString(" "))
-
-          Try {
-            val maybeProcess = Try(runtime.exec(cmd.toArray, envpForProcessor))
-
-            maybeProcess.flatMap { process =>
-              // NB. which stream we have to use and whether the message we are
-              // waiting for actually appears, depends on the log4j.xml file
-              // bundled in the application jar...
-              val is: InputStream = process.getInputStream
-              val isr = new InputStreamReader(is)
-              val br = new BufferedReader(isr)
-              var line: String = br.readLine()
-              while (line != null && !line.trim.contains("state: RUNNING")) {
-                if (line.contains("Exception")) {
-                  logger.error(line)
-                  throw new RuntimeException("could not start spark-submit")
-                }
-                line = br.readLine()
+      val maybeJson = org.json4s.native.JsonMethods.parseOpt(body)
+      val maybeSessionId = maybeJson.flatMap(_.extractOpt[SessionId])
+      maybeSessionId match {
+        case Some(sessionId) =>
+          // connect existing session
+          val session = sessionManager.getSession(sessionId.session_id)
+          session match {
+            case Failure(t) =>
+              InternalServerError ~> errorMsgContentType ~> ResponseString("Failed to get session")
+            case Success(sessionInfo) =>
+              sessionInfo match {
+                case SessionState.NotFound =>
+                  logger.warn("received a query JSON without a usable session_id")
+                  Unauthorized ~> errorMsgContentType ~> ResponseString("Unknown session_id")
+                case SessionState.Registering(key) =>
+                  logger.warn(s"processor for session $key has not registered yet")
+                  ServiceUnavailable ~> errorMsgContentType ~> ResponseString("This session has not been registered. Wait a second.")
+                case SessionState.Ready(host, port, key) =>
+                  logger.info(s"received login request for existing session (${sessionId}) from ${reqSource}")
+                  val sessionIdJson = write(SessionId(sessionId.session_id))
+                  Ok ~> errorMsgContentType ~> ResponseString(sessionIdJson)
               }
-              process.destroy()
-              // TODO: consider to check line is not null here
-              Success(1)
-            }
           }
-        case RunMode.Development(numThreads) =>
-          cmd.update(4, s"local[$numThreads]") // --master
-          cmd.update(6, "run.mode=development") // --conf
-          cmd.insertAll(7, Seq("--conf", s"jubaql.checkpointdir=$checkpointDir"))
-          logger.debug("executing: " + cmd.mkString(" "))
+        case None =>
+          // connect new session
+          val session = sessionManager.createNewSession()
+          session match {
+            case Failure(t) =>
+              InternalServerError ~> errorMsgContentType ~> ResponseString("Failed to create session")
+            case Success((sessionId, key)) =>
+              val callbackUrl = composeCallbackUrl(ipAddress, port, key)
 
-          Try {
-            val maybeProcess = Try(runtime.exec(cmd.toArray))
+              val runtime = Runtime.getRuntime
+              val cmd = mutable.ArrayBuffer(f"$sparkDistribution%s/bin/spark-submit",
+                "--class", "us.jubat.jubaql_server.processor.JubaQLProcessor",
+                "--master", "", // set later
+                "--conf", "", // set later
+                "--conf", s"log4j.configuration=file:$tmpLog4jPath",
+                fatjar,
+                callbackUrl)
+              logger.info(f"starting Spark in run mode $runMode%s (session_id: $sessionId%s)")
+              val divide = runMode match {
+                case RunMode.Production(zookeeper, numExecutors, coresPerExecutor, sparkJar) =>
+                  cmd.update(4, "yarn-cluster") // --master
+                  // When we run the processor on YARN, any options passed in with run.mode
+                  // will be passed to the SparkSubmit class, not the the Spark driver. To
+                  // get the run.mode passed one step further, we use the extraJavaOptions
+                  // variable. It is important to NOT ADD ANY QUOTES HERE or they will be
+                  // double-escaped on their way to the Spark driver and probably never end
+                  // up there.
+                  cmd.update(6, "spark.driver.extraJavaOptions=-Drun.mode=production " +
+                    s"-Djubaql.zookeeper=$zookeeper " +
+                    s"-Djubaql.checkpointdir=$checkpointDir") // --conf
+                  // also specify the location of the Spark jar file, if given
+                  val sparkJarParams = sparkJar match {
+                    case Some(url) => "--conf" :: s"spark.yarn.jar=$url" :: Nil
+                    case _ => Nil
+                  }
+                  cmd.insertAll(9, "--num-executors" :: numExecutors.toString ::
+                    "--executor-cores" :: coresPerExecutor.toString :: sparkJarParams)
+                  logger.debug("executing: " + cmd.mkString(" "))
+                  Try {
+                    val maybeProcess = Try(runtime.exec(cmd.toArray, envpForProcessor))
+                    maybeProcess.flatMap { process =>
+                      // NB. which stream we have to use and whether the message we are
+                      // waiting for actually appears, depends on the log4j.xml file
+                      // bundled in the application jar...
+                      val is: InputStream = process.getInputStream
+                      val isr = new InputStreamReader(is)
+                      val br = new BufferedReader(isr)
+                      var line: String = br.readLine()
+                      while (line != null && !line.trim.contains("state: RUNNING")) {
+                        if (line.contains("Exception")) {
+                          logger.error(line)
+                          throw new RuntimeException("could not start spark-submit")
+                        }
+                        line = br.readLine()
+                      }
+                      process.destroy()
+                      // TODO: consider to check line is not null here
+                      Success(1)
+                    }
+                  }
+                case RunMode.Development(numThreads) =>
+                  cmd.update(4, s"local[$numThreads]") // --master
+                  cmd.update(6, "run.mode=development") // --conf
+                  cmd.insertAll(7, Seq("--conf", s"jubaql.checkpointdir=$checkpointDir"))
+                  logger.debug("executing: " + cmd.mkString(" "))
 
-            maybeProcess.flatMap { process =>
-              handleSubProcessOutput(process.getInputStream, System.out)
-              handleSubProcessOutput(process.getErrorStream, System.err)
-              Success(1)
-            }
+                  Try {
+                    val maybeProcess = Try(runtime.exec(cmd.toArray))
+
+                    maybeProcess.flatMap { process =>
+                      handleSubProcessOutput(process.getInputStream, System.out)
+                      handleSubProcessOutput(process.getErrorStream, System.err)
+                      Success(1)
+                    }
+                  }
+                case RunMode.Test =>
+                  // do nothing in test mode.
+                  Success(1)
+              }
+              divide match {
+                case Success(_) =>
+                  logger.info(f"started Spark with callback URL $callbackUrl%s")
+                  logger.info(s"received login request for new session from ${reqSource}")
+                  val sessionIdJson = write(SessionId(sessionId))
+                  Ok ~> errorMsgContentType ~> ResponseString(sessionIdJson)
+                case Failure(e) =>
+                  logger.error(e.getMessage)
+                  InternalServerError ~> errorMsgContentType ~> ResponseString("Failed to start Spark\n")
+              }
           }
-        case RunMode.Test =>
-          // do nothing in test mode.
-          Success(1)
-      }
-      divide match {
-        case Success(_) =>
-          logger.info(f"started Spark with callback URL $callbackUrl%s")
-          val sessionIdJson = write(SessionId(sessionId))
-          Ok ~> errorMsgContentType ~> ResponseString(sessionIdJson)
-        case Failure(e) =>
-          logger.error(e.getMessage)
-          InternalServerError ~> errorMsgContentType ~> ResponseString("Failed to start Spark\n")
+
       }
 
     case req@POST(Path("/jubaql")) =>
       // TODO: treat very long input
       val body = readAllFromReader(req.reader)
       val reqSource = req.remoteAddr
-      logger.info(f"received HTTP request at /jubaql from $reqSource%s with body: $body%s")
+      logger.debug(f"received HTTP request at /jubaql from $reqSource%s with body: $body%s")
       val maybeJson = org.json4s.native.JsonMethods.parseOpt(body)
       val maybeQuery = maybeJson.flatMap(_.extractOpt[Query])
       maybeQuery match {
@@ -214,43 +239,36 @@ class GatewayPlan(ipAddress: String, port: Int,
           logger.warn("received an unacceptable JSON query")
           BadRequest ~> errorMsgContentType ~> ResponseString("Unacceptable JSON")
         case Some(query) =>
-          var maybeKey: Option[String] = None
-          var maybeLoc: Option[(String, Int)] = None
-          session2key.synchronized {
-            maybeKey = session2key.get(query.session_id)
-            maybeLoc = session2loc.get(query.session_id)
-          }
-          (maybeKey, maybeLoc) match {
-            case (None, None) =>
-              logger.warn("received a query JSON without a usable session_id")
-              Unauthorized ~> errorMsgContentType ~> ResponseString("Unknown session_id")
-            case (None, Some(loc)) =>
-              logger.error("inconsistent data in this gateway server")
-              InternalServerError ~> errorMsgContentType ~> ResponseString("Inconsistent data")
-            case (Some(key), None) =>
-              logger.warn(s"processor for session $key has not registered yet")
-              ServiceUnavailable ~> errorMsgContentType ~>
-                ResponseString("This session has not been registered. Wait a second.")
-            case (Some(key), Some(loc)) =>
-              // TODO: check forward query
-              val (host, port) = loc
+          val session = sessionManager.getSession(query.session_id)
+          session match {
+            case Failure(t) =>
+              InternalServerError ~> errorMsgContentType ~> ResponseString("Failed to get session")
+            case Success(sessionInfo) =>
+              sessionInfo match {
+                case SessionState.NotFound =>
+                  logger.warn("received a query JSON without a usable session_id")
+                  Unauthorized ~> errorMsgContentType ~> ResponseString("Unknown session_id")
+                case SessionState.Registering(key) =>
+                  logger.warn(s"processor for session $key has not registered yet")
+                  ServiceUnavailable ~> errorMsgContentType ~> ResponseString("This session has not been registered. Wait a second.")
+                case SessionState.Ready(host, port, key) =>
+                  val queryJson = write(QueryToProcessor(query.query)).toString
 
-              val queryJson = write(QueryToProcessor(query.query)).toString
+                  val url = :/(host, port) / "jubaql"
+                  val req = Http((url.POST << queryJson) > (x => x))
 
-              val url = :/(host, port) / "jubaql"
-              val req = Http((url.POST << queryJson) > (x => x))
-
-              logger.debug(f"forward query to processor ($host%s:$port%d)")
-              req.either.apply() match {
-                case Left(error) =>
-                  logger.error("failed to send request to processor [" + error.getMessage + "]")
-                  BadGateway ~> errorMsgContentType ~> ResponseString("Bad gateway")
-                case Right(result) =>
-                  val statusCode = result.getStatusCode
-                  val responseBody = result.getResponseBody
-                  val contentType = Option(result.getContentType).getOrElse("text/plain; charset=utf-8")
-                  logger.debug(f"got result from processor [$statusCode%d: $responseBody%s]")
-                  Status(statusCode) ~> ContentType(contentType) ~> ResponseString(responseBody)
+                  logger.debug(f"forward query to processor ($host%s:$port%d)")
+                  req.either.apply() match {
+                    case Left(error) =>
+                      logger.error("failed to send request to processor [" + error.getMessage + "]")
+                      BadGateway ~> errorMsgContentType ~> ResponseString("Bad gateway")
+                    case Right(result) =>
+                      val statusCode = result.getStatusCode
+                      val responseBody = result.getResponseBody
+                      val contentType = Option(result.getContentType).getOrElse("text/plain; charset=utf-8")
+                      logger.debug(f"got result from processor [$statusCode%d: $responseBody%s]")
+                      Status(statusCode) ~> ContentType(contentType) ~> ResponseString(responseBody)
+                  }
               }
           }
       }
@@ -264,12 +282,13 @@ class GatewayPlan(ipAddress: String, port: Int,
       val maybeUnregister = maybeJson.flatMap(_.extractOpt[Unregister]).
         filter(_.action == "unregister")
 
-      if (!maybeRegister.isEmpty)
+      if (!maybeRegister.isEmpty) {
         logger.info(f"start registration (key: $key%s)")
-      else if (!maybeUnregister.isEmpty)
+      } else if (!maybeUnregister.isEmpty) {
         logger.info(f"start unregistration (key: $key%s)")
-      else
+      } else {
         logger.info(f"start registration or unregistration (key: $key%s)")
+      }
 
       if (maybeJson.isEmpty) {
         logger.warn("received query not in JSON format")
@@ -278,31 +297,31 @@ class GatewayPlan(ipAddress: String, port: Int,
         logger.warn("received unacceptable JSON query")
         BadRequest ~> errorMsgContentType ~> ResponseString("Unacceptable JSON")
       } else {
-        session2key.synchronized {
-          val maybeSessionId = key2session.get(key)
-          if (!maybeRegister.isEmpty) { // register
-            val register = maybeRegister.get
-            val (ip, port) = (register.ip, register.port)
-            logger.debug(f"registering $ip%s:$port%d")
-            maybeSessionId match {
-              case None =>
-                logger.error("attempted to register unknown key")
-                Unauthorized ~> errorMsgContentType ~> ResponseString("Unknown key")
-              case Some(sessionId) =>
-                session2loc += (sessionId -> (ip, port))
-                Ok ~> errorMsgContentType ~> ResponseString("Successfully registered")
-            }
-          } else { // unregister
-            logger.debug("unregistering")
-            maybeSessionId match {
-              case Some(sessionId) => // unregistering an existent key
-                session2key -= sessionId
-                key2session -= key
-                session2loc -= sessionId
-              case _ => // unregistering a nonexistent key
-                ()
-            }
-            Ok ~> errorMsgContentType ~> ResponseString("Successfully unregistered")
+        if (!maybeRegister.isEmpty) { // register
+          val register = maybeRegister.get
+          val (ip, port) = (register.ip, register.port)
+          logger.debug(f"registering $ip%s:$port%d")
+          val result = sessionManager.attachProcessorToSession(ip, port, key)
+          result match {
+            case Failure(t) =>
+              InternalServerError ~> errorMsgContentType ~> ResponseString(s"failed to register key : ${key}")
+            case Success(sessionId) =>
+              logger.info(s"registered session. sessionId : $sessionId")
+              Ok ~> errorMsgContentType ~> ResponseString("Successfully registered")
+          }
+        } else { // unregister
+          logger.debug("unregistering")
+          val result = sessionManager.deleteSession(key)
+          result match {
+            case Failure(t) =>
+              InternalServerError ~> errorMsgContentType ~> ResponseString(s"failed to unregister key : ${key}")
+            case Success((sessionId, key)) =>
+              if (sessionId != null) {
+                logger.info(s"unregistered session. sessionId: ${sessionId}")
+              } else {
+                logger.info(s"already delete session. key: ${key}")
+              }
+              Ok ~> errorMsgContentType ~> ResponseString("Successfully unregistered")
           }
         }
       }
@@ -329,21 +348,9 @@ class GatewayPlan(ipAddress: String, port: Int,
     }
     sb.toString
   }
-}
 
-// An alphanumeric string generator.
-object Alphanumeric {
-  val random = new Random()
-  val chars = "0123456789abcdefghijklmnopqrstuvwxyz"
-
-  def generate(length: Int): String = {
-    val ret = new Array[Char](length)
-    this.synchronized {
-      for (i <- 0 until ret.length) {
-        ret(i) = chars(random.nextInt(chars.length))
-      }
-    }
-    new String(ret)
+  def close():Unit = {
+    sessionManager.close()
   }
 }
 

--- a/gateway/src/main/scala/us/jubat/jubaql_server/gateway/SessionManager.scala
+++ b/gateway/src/main/scala/us/jubat/jubaql_server/gateway/SessionManager.scala
@@ -1,0 +1,465 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2015 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+package us.jubat.jubaql_server.gateway
+
+import scala.collection.mutable
+import scala.collection.mutable._
+import scala.util.Random
+import org.json4s._
+import org.json4s.native.JsonMethods._
+import com.typesafe.scalalogging.slf4j.LazyLogging
+import scala.util.{Try, Success, Failure}
+
+/**
+ * Session Management Class
+ */
+class SessionManager(gatewayId: String, sessionStore: SessionStore = new NonPersistentStore) extends LazyLogging {
+  implicit val formats = DefaultFormats
+
+  // key = sessionId, value = keyInfo
+  val session2key: mutable.Map[String, String] = new mutable.HashMap()
+  // key = keyInfo, value = sessionId
+  // key: identification required for registration / unregistration
+  val key2session: mutable.Map[String, String] = new mutable.HashMap()
+  // key = sessionId, vale = Processor's connectionInfo(host, port)
+  val session2loc: mutable.Map[String, (String, Int)] = new mutable.HashMap()
+
+  // initialize session store(specific processing)
+  sessionStore.registerGateway(gatewayId)
+
+  // initialize cache from session store
+  initCache()
+
+  // --- session controller method ---
+  /**
+   * initialize cache from session store
+   */
+  def initCache(): Unit = {
+    val sessionMap = sessionStore.getAllSessions(gatewayId)
+    session2key.synchronized {
+      for ((sessionId, sessionInfo) <- sessionMap) {
+        sessionInfo match {
+          case completeSesion: SessionState.Ready =>
+            session2key += sessionId -> completeSesion.key
+            key2session += completeSesion.key -> sessionId
+            session2loc += sessionId -> (completeSesion.host, completeSesion.port)
+            sessionStore.addDeleteListener(gatewayId, sessionId, deleteFunction)
+          case registeringSession: SessionState.Registering =>
+            logger.debug(s"Registering session not add to cache. session: ${sessionId}")
+          case _ =>
+            logger.info(s"Invalid session. exclude session: ${sessionId}")
+        }
+      }
+    }
+  }
+
+  /**
+   * create new session
+   * @return resultCreateSession(session ID and registration key)
+   */
+  def createNewSession(): Try[(String, String)] = {
+    var lockObj: SessionLock = null
+    val result = Try {
+      lockObj = lock()
+      val (sessionId, key) = createId()
+      sessionStore.preregisterSession(gatewayId, sessionId, key)
+      sessionStore.addDeleteListener(gatewayId, sessionId, deleteFunction)
+      session2key.synchronized {
+        session2key += (sessionId -> key)
+        key2session += (key -> sessionId)
+      }
+      (sessionId, key)
+    }
+    unlock(lockObj)
+    result
+  }
+
+  /**
+   * get Session
+   * if not found in cache, contact to session store
+   * @param sessionId: sessionId
+   * @return SessionInformation (processor's host, processor's port, regstrationKey)
+   */
+  def getSession(sessionId: String): Try[SessionState] = {
+    Try {
+      val cacheSession: SessionState = getSessionFromCache(sessionId)
+      cacheSession match {
+        case completeSession: SessionState.Ready => completeSession
+        case registeringSession: SessionState.Registering => registeringSession
+        case SessionState.NotFound =>
+          // session not found in cache, contact session store.
+          val storeSession = sessionStore.getSession(gatewayId, sessionId)
+          storeSession match {
+            case SessionState.NotFound => storeSession
+            case SessionState.Inconsistent =>
+              throw new Exception(s"Inconsistent data. sessionId: ${sessionId}")
+            case completeSession: SessionState.Ready =>
+              val host = completeSession.host
+              val port = completeSession.port
+              val key = completeSession.key
+              sessionStore.addDeleteListener(gatewayId, sessionId, deleteFunction)
+              session2key.synchronized {
+                session2key += sessionId -> key
+                key2session += key -> sessionId
+                session2loc += sessionId -> (host, port)
+              }
+              completeSession
+            case registeringSession: SessionState.Registering =>
+              registeringSession
+          }
+      }
+    }
+  }
+
+  /**
+   * get session from cache
+   * @param sessionId session ID
+   * @return session information
+   */
+  def getSessionFromCache(sessionId: String): SessionState = {
+    session2key.get(sessionId) match {
+      case Some(key) =>
+        session2loc.get(sessionId) match {
+          case Some(loc) =>
+            if (key != null) {
+              SessionState.Ready(loc._1, loc._2, key)
+            } else {
+              throw new Exception(s"Inconsistent data. sessionId: ${sessionId}")
+            }
+          case None =>
+            // not yet registered sessionId.
+            SessionState.Registering(key)
+        }
+      case None =>
+        SessionState.NotFound
+    }
+  }
+
+  /**
+   * attach Processor Information to session
+   * @param host Processor's host
+   * @param port Processor's port
+   * @param key registration key
+   * @return attachResult
+   */
+  def attachProcessorToSession(host: String, port: Int, key: String): Try[String] = {
+    var lockObj: SessionLock = null
+    val result = Try {
+      val sessionId = key2session.get(key) match {
+        case Some(sessionId) => sessionId
+        case None => throw new Exception(s"non exist sessionId. key: ${key}")
+      }
+      lockObj = lock()
+      sessionStore.registerSession(gatewayId, sessionId, host, port, key)
+      sessionStore.addDeleteListener(gatewayId, sessionId, deleteFunction)
+      session2key.synchronized {
+        session2loc += (sessionId -> (host, port))
+      }
+      sessionId
+    }
+    unlock(lockObj)
+    result
+  }
+
+  /**
+   * delete Session
+   * @param key registration key
+   * @return deleteResult(sessionId, key)
+   */
+  def deleteSession(key: String): Try[(String, String)] = {
+    var lockObj: SessionLock = null
+    val result = Try {
+      key2session.get(key) match {
+        case Some(sessionId) =>
+          lockObj = lock()
+          sessionStore.deleteSession(gatewayId, sessionId)
+          session2key.synchronized {
+            key2session -= key
+            session2key -= sessionId
+            session2loc -= sessionId
+          }
+          (sessionId, key)
+        case None =>
+          logger.debug(s"non exist sessionId. key: ${key}")
+          (null, key)
+      }
+    }
+    unlock(lockObj)
+    result
+  }
+
+  /**
+   * gateway session lock
+   * @return Lock Object
+   */
+  def lock(): SessionLock = {
+    val lock = sessionStore.lock(gatewayId)
+    logger.debug(s"locked: $gatewayId")
+    lock
+  }
+
+  /**
+   * gateway session unlock
+   * @param lock Lock Object
+   */
+  def unlock(lock: SessionLock): Unit = {
+    if (lock != null) {
+      try {
+        sessionStore.unlock(lock)
+        logger.debug(s"unlocked: gatewayId = $gatewayId")
+      } catch {
+        case e: Exception =>
+          logger.error("failed to unlock.", e)
+      }
+    } else {
+      logger.debug(s"not lock. gatewayId = $gatewayId")
+    }
+  }
+
+  /**
+   * generate sessionId and key
+   * @return (sessionId, registrationKey)
+   */
+  def createId(): (String, String) = {
+    session2key.synchronized {
+      var sessionId = ""
+      var key = ""
+
+      do {
+        sessionId = Alphanumeric.generate(20)
+      } while (session2key.get(sessionId) != None)
+      do {
+        key = Alphanumeric.generate(20)
+      } while (key2session.get(key) != None)
+      (sessionId, key)
+    }
+  }
+
+  /**
+   * delete session in cache. called by delete listeners.
+   * @param sessionId session ID
+   */
+  def deleteFunction(sessionId: String): Unit = {
+    logger.debug("delete session from cache. sessionId = ${sessionId}")
+    session2key.synchronized {
+      val keyOpt = session2key.get(sessionId)
+      keyOpt match {
+        case Some(key) => key2session -= key
+        case None => //Nothing
+      }
+      session2key -= sessionId
+      session2loc -= sessionId
+    }
+  }
+
+  /**
+   * get session from store
+   * @param sessionId session ID
+   * @return session information
+   */
+  def getSessionFromStore(sessionId: String): SessionState = {
+    sessionStore.getSession(gatewayId, sessionId)
+  }
+
+  /**
+   * close
+   */
+  def close(): Unit = {
+    sessionStore.close()
+  }
+}
+
+/**
+ *  An alphanumeric string generator.
+ */
+object Alphanumeric {
+  val random = new Random(new java.security.SecureRandom())
+  val chars = "0123456789abcdefghijklmnopqrstuvwxyz"
+
+  /**
+   * generate ID
+   * @param length generated ID length
+   */
+  def generate(length: Int): String = {
+    val ret = new Array[Char](length)
+    this.synchronized {
+      for (i <- 0 until ret.length) {
+        ret(i) = chars(random.nextInt(chars.length))
+      }
+    }
+
+    new String(ret)
+  }
+}
+
+/**
+ * Session Store Interface
+ */
+trait SessionStore {
+  implicit val formats = DefaultFormats
+
+  /**
+   * get All Session by gatewayId
+   * @param gatewayId gateway ID
+   * @return SessionInformation Map(key   = sessionId, value = SessionState)
+   */
+  def getAllSessions(gatewayId: String): Map[String, SessionState]
+
+  /**
+   * get Session
+   * if not found in cache, contact to session store
+   * @param gatewayId gateway ID
+   * @param sessionId session ID
+   * @return SessionState
+   */
+  def getSession(gatewayId: String, sessionId: String): SessionState
+
+  /**
+   * register SessionId to session store
+   * @param gatewayId gateway ID
+   * @param sessionId session ID
+   * @param key registration key
+   */
+  def preregisterSession(gatewayId: String, sessionId: String, key: String): Unit
+
+  /**
+   * register Session to session store
+   * @param gatewayId gateway ID
+   * @param sessionId session ID
+   * @param host Processor's host
+   * @param port Processor's port
+   * @param key registration key
+   */
+  def registerSession(gatewayId: String, sessionId: String, host: String, port: Int, key: String): Unit
+
+  /**
+   * delete Session
+   * @param gatewayId gateway ID
+   * @param sessionId session Id
+   */
+  def deleteSession(gatewayId: String, sessionId: String): Unit
+
+  /**
+   * gateway session lock
+   * @param gatewayId gateway ID
+   * @return Lock Object
+   */
+  def lock(gatewayId: String): SessionLock
+
+  /**
+   * gateway session unlock
+   * @param lock Lock Object
+   */
+  def unlock(lock: SessionLock): Unit
+
+  /**
+   * register delete listener
+   * @param gatewayId gateway Id
+   * @param sessionId session Id
+   * @param deleteFunction delete-event trigger, call function
+   */
+  def addDeleteListener(gatewayId: String, sessionId: String, deleteFunction: Function1[String, Unit] = null): Unit
+
+  /**
+   * initialize session store
+   * @param gatewayId gateway Id
+   */
+  def registerGateway(gatewayId: String): Unit
+
+  /**
+   * close
+   */
+  def close(): Unit
+
+  // --- utility method ---
+  /**
+   * extract Session Information for jsonString
+   * @param jsonString
+   * @return SessionInfo
+   */
+  def extractSessionInfo(jsonString: String): SessionState = {
+    try {
+      val jsonData = parse(jsonString)
+      if (jsonData != JNothing && jsonData.children.length > 0) {
+        val host = (jsonData \ "host") match {
+          case JNothing => null
+          case value: JValue => value.extract[String]
+        }
+        val port = (jsonData \ "port") match {
+          case JNothing => null
+          case value: JValue => value.extract[String]
+        }
+        val key = (jsonData \ "key") match {
+          case JNothing => null
+          case value: JValue => value.extract[String]
+        }
+        if (host == null && port == null && key == null) {
+          SessionState.NotFound
+        } else if (host == null && port == null && key != null) {
+          SessionState.Registering(key)
+        } else if (host != null && port != null && key != null) {
+          SessionState.Ready(host, port.toInt, key)
+        } else {
+          SessionState.Inconsistent
+        }
+      } else {
+        SessionState.NotFound
+      }
+    } catch {
+      case e: Throwable =>
+        throw e
+    }
+  }
+}
+
+/**
+ * Session Lock Object
+ */
+class SessionLock(lock: Any) {
+  val lockObject = lock
+}
+
+/**
+ * SessionStore for non-persist
+ */
+class NonPersistentStore extends SessionStore {
+  override def getAllSessions(gatewayId: String): Map[String, SessionState] = Map.empty[String, SessionState]
+  override def getSession(gatewayId: String, sessionId: String): SessionState = SessionState.NotFound
+  override def preregisterSession(gatewayId: String, sessionId: String, key: String): Unit = {}
+  override def registerSession(gatewayId: String, sessionId: String, host: String, port: Int, key: String): Unit = {}
+  override def deleteSession(gatewayId: String, sessionId: String): Unit = {}
+  override def lock(gatewayId: String): SessionLock = { null }
+  override def unlock(lock: SessionLock): Unit = {}
+  override def addDeleteListener(gatewayId: String, sessionId: String, deleteFunction: Function1[String, Unit] = null): Unit = {}
+  override def registerGateway(gatewayId: String): Unit = {}
+  override def close(): Unit = {}
+}
+
+/**
+ * SessionInfo
+ */
+trait SessionState
+
+object SessionState {
+  // Session ready
+  case class Ready(host: String, port: Int, key: String) extends SessionState
+  // Registering yet
+  case class Registering(key: String) extends SessionState
+  // Session Inconsistent
+  case object Inconsistent extends SessionState
+  // Unknown session
+  case object NotFound extends SessionState
+}

--- a/gateway/src/main/scala/us/jubat/jubaql_server/gateway/ZookeeperStore.scala
+++ b/gateway/src/main/scala/us/jubat/jubaql_server/gateway/ZookeeperStore.scala
@@ -1,0 +1,216 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2015 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+package us.jubat.jubaql_server.gateway
+
+import com.typesafe.scalalogging.slf4j.LazyLogging
+import scala.collection.mutable
+import scala.collection.mutable._
+import org.apache.curator._
+import org.apache.curator.retry._
+import org.apache.curator.framework._
+import org.apache.curator.framework.recipes.locks._
+import collection.JavaConversions._
+import org.apache.zookeeper.KeeperException
+import org.apache.zookeeper.KeeperException.NoNodeException
+import org.apache.curator.framework.api.CuratorListener
+import org.apache.curator.framework.api.CuratorEvent
+import org.apache.zookeeper.Watcher
+import org.apache.curator.framework.listen.ListenerContainer
+import java.util.concurrent.TimeUnit
+
+/**
+ * ZooKeeper Store Class
+ */
+class ZookeeperStore extends SessionStore with LazyLogging {
+
+  val zkJubaQLPath: String = "/jubaql"
+  val zkSessionPath: String = "/jubaql/session"
+
+  val lockNodeName = "locks"
+  val leasesNodeName = "leases"
+  //lock keep time(unit: seconds)
+  val lockTimeout: Long = 300
+  // retry sleep time(unit: ms)
+  val retrySleepTimeMs: Int = 5000
+  val retryCount: Int = 1
+
+  val zookeeperString: String = scala.util.Properties.propOrElse("jubaql.zookeeper", "")
+  val retryPolicy: RetryPolicy = new RetryNTimes(retryCount, retrySleepTimeMs)
+
+  logger.info(s"connecting to ZooKeeper : ${zookeeperString}")
+  val zookeeperClient: CuratorFramework = CuratorFrameworkFactory.newClient(zookeeperString, retryPolicy)
+
+  zookeeperClient.start()
+  if (!zookeeperClient.getZookeeperClient.blockUntilConnectedOrTimedOut) {
+    zookeeperClient.close()
+    logger.error(s"zookeeper connection timeout. zookeeper: ${zookeeperString}")
+    throw new Exception("failed to connected zookeeper")
+  }
+  logger.info(s"connected to ZooKeeper : ${zookeeperString}")
+
+  override def getAllSessions(gatewayId: String): Map[String, SessionState] = {
+    var result = Map.empty[String, SessionState]
+    try {
+      val isExist = zookeeperClient.checkExists().forPath(s"${zkSessionPath}/${gatewayId}")
+      if (isExist != null) {
+        val sessionIdList = zookeeperClient.getChildren.forPath(s"${zkSessionPath}/${gatewayId}")
+        for (sessionId <- sessionIdList) {
+          val sessionInfo = getSession(gatewayId, sessionId)
+          result += sessionId -> sessionInfo
+        }
+      }
+    } catch {
+      case e: Exception =>
+        logger.error("failed to get all session.", e)
+        throw e
+    }
+    return result
+  }
+
+  override def getSession(gatewayId: String, sessionId: String): SessionState = {
+    try {
+      val sessionByteArray = zookeeperClient.getData().forPath(s"${zkSessionPath}/${gatewayId}/${sessionId}")
+      val sessionJsonString = new String(sessionByteArray, "UTF-8")
+      extractSessionInfo(sessionJsonString)
+    } catch {
+      case e: NoNodeException =>
+        logger.debug(s"not found session. sesionId: ${sessionId}")
+        SessionState.NotFound
+      case e: Exception =>
+        logger.error(s"failed to get session. sessionId: ${sessionId}", e)
+        throw e
+    }
+  }
+
+  override def preregisterSession(gatewayId: String, sessionId: String, key: String): Unit = {
+    try {
+      val isExists = zookeeperClient.checkExists().forPath(s"${zkSessionPath}/${gatewayId}/${sessionId}")
+      if (isExists == null) {
+        zookeeperClient.create().forPath(s"${zkSessionPath}/${gatewayId}/${sessionId}", s"""{"key":"$key"}""".getBytes("UTF-8"))
+      } else {
+        throw new IllegalStateException(s"already exists session. sessionId: ${sessionId}")
+      }
+    } catch {
+      case e: Exception =>
+        logger.error("failed to pre-register session. sessionId: ${sessionId}", e)
+        throw e
+    }
+  }
+
+  override def registerSession(gatewayId: String, sessionId: String, host: String, port: Int, key: String): Unit = {
+    try {
+      val isExists = zookeeperClient.checkExists().forPath(s"${zkSessionPath}/${gatewayId}/${sessionId}")
+      if (isExists != null) {
+        zookeeperClient.setData().forPath(s"${zkSessionPath}/${gatewayId}/${sessionId}", s"""{"host":"$host","port":$port,"key":"$key"}""".getBytes("UTF-8"))
+      } else {
+        throw new IllegalStateException(s"non exists session. sessionId: ${sessionId}")
+      }
+    } catch {
+      case e: Exception =>
+        logger.error(s"failed to register session. sessionId: ${sessionId}")
+        throw e
+    }
+  }
+
+  override def deleteSession(gatewayId: String, sessionId: String): Unit = {
+    try {
+      zookeeperClient.delete().forPath(s"${zkSessionPath}/${gatewayId}/${sessionId}")
+    } catch {
+      case e: NoNodeException => logger.warn(s"No exist Node. sessionId : $sessionId")
+      case e: Exception =>
+        logger.error(s"failed to delete session. sessionId: $sessionId", e)
+        throw e
+    }
+  }
+
+  override def lock(gatewayId: String): SessionLock = {
+    val mutex: InterProcessSemaphoreMutex = try {
+      val mutex = new InterProcessSemaphoreMutex(zookeeperClient, s"${zkSessionPath}/${gatewayId}")
+      mutex.acquire(lockTimeout, TimeUnit.SECONDS)
+      mutex
+    } catch {
+      case e: Exception =>
+        logger.error("failed to create lock object", e)
+        throw e
+    }
+    new SessionLock(mutex)
+  }
+
+  override def unlock(lock: SessionLock): Unit = {
+    val mutex = lock.lockObject
+    if (mutex != null && mutex.isInstanceOf[InterProcessSemaphoreMutex]) {
+      try {
+        mutex.asInstanceOf[InterProcessSemaphoreMutex].release()
+      } catch {
+        case e: Exception =>
+          logger.error("failed to unlock", e)
+          throw e
+      }
+    } else {
+      logger.error(s"failed to unlock. illegal lock object class: ${mutex.getClass()}")
+      throw new Exception(s"failed to unlock. illegal lock object class: ${mutex.getClass()}")
+    }
+  }
+
+  override def addDeleteListener(gatewayId: String, sessionId: String, deleteFunction: Function1[String, Unit]): Unit = {
+    try {
+      zookeeperClient.synchronized {
+        val listenerSize = if (zookeeperClient.getCuratorListenable.isInstanceOf[ListenerContainer[CuratorListener]]) {
+          val container = zookeeperClient.getCuratorListenable.asInstanceOf[ListenerContainer[CuratorListener]]
+          container.size()
+        } else {
+          throw new Exception(s"invalid listener class. class: ${zookeeperClient.getCuratorListenable.getClass}")
+        }
+        if (sessionId != lockNodeName && sessionId != leasesNodeName) {
+          if (listenerSize == 0) {
+            val listener = new CuratorListener() {
+              override def eventReceived(client: CuratorFramework, event: CuratorEvent): Unit = {
+                if (event.getWatchedEvent.getType == Watcher.Event.EventType.NodeDeleted) {
+                  val deletedNodePath = event.getPath
+                  val deletedSessionID = deletedNodePath.substring(deletedNodePath.lastIndexOf("/") + 1, deletedNodePath.length)
+                  deleteFunction(deletedSessionID)
+                }
+              }
+            }
+            zookeeperClient.getCuratorListenable.addListener(listener)
+          }
+          zookeeperClient.getChildren.watched().forPath(s"${zkSessionPath}/${gatewayId}/${sessionId}")
+        }
+      }
+    } catch {
+      case e: Exception =>
+        logger.error(s"failed to add delete listener. sessionId: ${sessionId}", e)
+        throw e
+    }
+  }
+
+  override def registerGateway(gatewayId: String): Unit = {
+    if (zookeeperClient.checkExists().forPath(zkJubaQLPath) == null) {
+      zookeeperClient.create().forPath(zkJubaQLPath, new Array[Byte](0))
+    }
+    if (zookeeperClient.checkExists().forPath(zkSessionPath) == null) {
+      zookeeperClient.create().forPath(zkSessionPath, new Array[Byte](0))
+    }
+    if (zookeeperClient.checkExists().forPath(s"${zkSessionPath}/${gatewayId}") == null) {
+      zookeeperClient.create().forPath(s"${zkSessionPath}/${gatewayId}", new Array[Byte](0))
+    }
+  }
+
+  override def close(): Unit = {
+    zookeeperClient.close()
+    logger.info("zookeeperClient closed")
+  }
+}

--- a/processor/src/main/scala/us/jubat/jubaql_server/processor/JubaQLService.scala
+++ b/processor/src/main/scala/us/jubat/jubaql_server/processor/JubaQLService.scala
@@ -325,12 +325,17 @@ class JubaQLService(sc: SparkContext, runMode: RunMode, checkpointDir: String)
         }
         // TODO: location, resource
         val resource = Resource(priority = 0, memory = 256, virtualCores = 1)
+
+        val gatewayAddress = scala.util.Properties.propOrElse("jubaql.gateway.address","")
+        val sessionId = scala.util.Properties.propOrElse("jubaql.processor.sessionId","")
+        val applicationName = s"JubatusOnYarn:$gatewayAddress:$sessionId:${jubaType.name}:${cm.modelName}"
+
         val juba: ScFuture[JubatusYarnApplication] = runMode match {
           case RunMode.Production(zookeeper) =>
             val location = zookeeper.map {
               case (host, port) => Location(InetAddress.getByName(host), port)
             }
-            JubatusYarnApplication.start(cm.modelName, jubaType, location, configJsonStr, resource, 2)
+            JubatusYarnApplication.start(cm.modelName, jubaType, location, configJsonStr, resource, 2, applicationName)
           case RunMode.Development =>
             LocalJubatusApplication.start(cm.modelName, jubaType, configJsonStr)
         }


### PR DESCRIPTION
By applying this patch, JubaQL gateway now persists session records to ZooKeeper, so that:
- gateway instances can be clustered to provide high availability and performance
- session records can be recovered after restarting Gateway, even in non-HA configuration

In other words, this patch resolves SPoF issue of JubaQL system.
### External changes introduced in this patch
- This patch adds the following options to Gateway.
  - `--persist`: enables session persisntence.  When using this option, ZooKeeper hosts must be specified like `-Djubaql.zookeeper=localhost:2181`.
  - `--gatewayId xxx`: specify gateway cluster name.  Runs in single node mode when omitted.
- This patch adds dependency to Apache Curator library, which is a client library for ZooKeeper.
- This patch changes the login protocol between Client and Gateway. When clients reconnect to the existing session, clients need to send login request (along with the session ID) to ensure that the session exists.  (client side fix: https://github.com/jubatus/jubaql-client/pull/1)
- Session persistence creates ZooKeeper node under `/jubaql/session`.
### TODOs
- This patch depends on #4. We'll rebase this patch later.
- Documentation must be updated.
