### PR TITLE
(WIP) detect spark-submit launch failures

### DIFF
--- a/gateway/build.sbt
+++ b/gateway/build.sbt
@@ -20,8 +20,14 @@ libraryDependencies ++= Seq(
   "net.databinder.dispatch"    %% "dispatch-core"  % "0.11.2",
   // parsing of program arguments
   "com.github.scopt"           %% "scopt"          % "3.2.0",
+  // apache curator
+  "org.apache.curator" % "apache-curator" % "2.8.0",
+  "org.apache.curator" % "curator-framework" % "2.8.0",
+  "org.apache.curator" % "curator-recipes" % "2.8.0",
   // testing
-  "org.scalatest"     %% "scalatest"               % "2.2.1"
+  "org.scalatest"     %% "scalatest"               % "2.2.1",
+  "org.apache.curator" % "curator-test" % "2.8.0",
+  "org.scala-lang.modules" %% "scala-async" % "0.9.2"
 )
 
 // disable parallel test execution to avoid BindException when mocking

--- a/gateway/src/main/resources/log4j.xml
+++ b/gateway/src/main/resources/log4j.xml
@@ -16,7 +16,12 @@
     <logger name="com.ning">
         <level value="info"/>
     </logger>
-
+    <logger name="org.apache.zookeeper">
+        <level value="error"/>
+    </logger>
+    <logger name="org.apache.curator">
+        <level value="error"/>
+    </logger>
     <root>
         <priority value="debug"/>
         <appender-ref ref="console"/>

--- a/gateway/src/main/scala/us/jubat/jubaql_server/gateway/GatewayPlan.scala
+++ b/gateway/src/main/scala/us/jubat/jubaql_server/gateway/GatewayPlan.scala
@@ -24,13 +24,15 @@ import us.jubat.jubaql_server.gateway.json.{Unregister, Register, Query, Session
 import scala.collection.mutable
 import org.json4s.DefaultFormats
 import org.json4s.native.Serialization.write
-import scala.util.Random
 import scala.util.{Try, Success, Failure}
 import java.io._
 import dispatch._
 import dispatch.Defaults._
 import java.util.jar.JarFile
 import java.nio.file.{StandardCopyOption, Files}
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.collection.mutable.ArrayBuffer
 
 // A Netty plan using async IO
 // cf. <http://unfiltered.databinder.net/Bindings+and+Servers.html>.
@@ -40,7 +42,7 @@ import java.nio.file.{StandardCopyOption, Files}
 class GatewayPlan(ipAddress: String, port: Int,
                   envpForProcessor: Array[String], runMode: RunMode,
                   sparkDistribution: String, fatjar: String,
-                  checkpointDir: String)
+                  checkpointDir: String, gatewayId: String, persistSession: Boolean)
   extends cycle.Plan
   /* With cycle.SynchronousExecution, there is a group of N (16?) threads
      (named "nioEventLoopGroup-5-*") that will process N requests in
@@ -64,10 +66,20 @@ class GatewayPlan(ipAddress: String, port: Int,
   with LazyLogging {
   lazy val underlying = new MemoryAwareThreadPoolExecutor(16, 65536, 1048576)
 
-  // holds session ids mapping to keys and host:port locations, respectively
-  val session2key: mutable.Map[String, String] = new mutable.HashMap()
-  val key2session: mutable.Map[String, String] = new mutable.HashMap()
-  val session2loc: mutable.Map[String, (String, Int)] = new mutable.HashMap()
+  val Lineseparator = System.lineSeparator()
+
+  // SessionManager: holds session ids mapping to keys and host:port locations, respectively
+  val sessionManager = try {
+    persistSession match {
+      case true => new SessionManager(gatewayId, new ZookeeperStore)
+      case false => new SessionManager(gatewayId)
+    }
+  } catch {
+    case e: Throwable => {
+      logger.error("failed to start session manager", e)
+      throw e
+    }
+  }
 
   /* When starting the processor using spark-submit, we rely on a certain
    * logging behavior. It seems like the log4j.xml file bundled with
@@ -93,113 +105,195 @@ class GatewayPlan(ipAddress: String, port: Int,
 
   val errorMsgContentType = ContentType("text/plain; charset=utf-8")
 
+  val DefaultTimeout: Long = 60000
+  val submitTimeout = try {
+    val timeoutString: String = System.getProperty("jubaql.gateway.submitTimeout", DefaultTimeout.toString)
+    val timeout = timeoutString.toLong
+    if (timeout < 1) {
+      throw new Exception(s"""jubaql.gateway.submitTimeout value must be "1 <= n <= ${Long.MaxValue}"""")
+    }
+    timeout
+  } catch {
+    case e: Exception =>
+      logger.warn(s"failed get jubaql.gateway.submitTimeout property. Use default Timeout : ${DefaultTimeout}", e)
+      DefaultTimeout
+  }
+  logger.debug(s"set spark-submit startingTimeout = $submitTimeout ms")
+
   implicit val formats = DefaultFormats
 
   def intent = {
     case req@POST(Path("/login")) =>
-      var sessionId = ""
-      var key = ""
+      val body = readAllFromReader(req.reader)
       val reqSource = req.remoteAddr
-      logger.info(f"received HTTP request at /login from $reqSource%s")
-      session2key.synchronized {
-        do {
-          sessionId = Alphanumeric.generate(20) // TODO: generate in a more sophisticated way.
-        } while (session2key.get(sessionId) != None)
-        do {
-          key = Alphanumeric.generate(20) // TODO: generate in a more sophisticated way.
-        } while (key2session.get(key) != None)
-        session2key += (sessionId -> key)
-        key2session += (key -> sessionId)
-      }
-      val callbackUrl = composeCallbackUrl(ipAddress, port, key)
+      logger.debug(f"received HTTP request at /login from $reqSource%s with body: $body%s")
 
-      val runtime = Runtime.getRuntime
-      val cmd = mutable.ArrayBuffer(f"$sparkDistribution%s/bin/spark-submit",
-                                    "--class", "us.jubat.jubaql_server.processor.JubaQLProcessor",
-                                    "--master", "", // set later
-                                    "--conf", "", // set later
-                                    "--conf", s"log4j.configuration=file:$tmpLog4jPath",
-                                    fatjar,
-                                    callbackUrl)
-      logger.info(f"starting Spark in run mode $runMode%s (session_id: $sessionId%s)")
-      val divide = runMode match {
-        case RunMode.Production(zookeeper, numExecutors, coresPerExecutor, sparkJar) =>
-          cmd.update(4, "yarn-cluster") // --master
-          // When we run the processor on YARN, any options passed in with run.mode
-          // will be passed to the SparkSubmit class, not the the Spark driver. To
-          // get the run.mode passed one step further, we use the extraJavaOptions
-          // variable. It is important to NOT ADD ANY QUOTES HERE or they will be
-          // double-escaped on their way to the Spark driver and probably never end
-          // up there.
-          cmd.update(6, "spark.driver.extraJavaOptions=-Drun.mode=production " +
-            s"-Djubaql.zookeeper=$zookeeper " +
-            s"-Djubaql.checkpointdir=$checkpointDir") // --conf
-          // also specify the location of the Spark jar file, if given
-          val sparkJarParams = sparkJar match {
-            case Some(url) => "--conf" :: s"spark.yarn.jar=$url" :: Nil
-            case _ => Nil
-          }
-          cmd.insertAll(9, "--num-executors" :: numExecutors.toString ::
-            "--executor-cores" :: coresPerExecutor.toString :: sparkJarParams)
-          logger.debug("executing: " + cmd.mkString(" "))
-
-          Try {
-            val maybeProcess = Try(runtime.exec(cmd.toArray, envpForProcessor))
-
-            maybeProcess.flatMap { process =>
-              // NB. which stream we have to use and whether the message we are
-              // waiting for actually appears, depends on the log4j.xml file
-              // bundled in the application jar...
-              val is: InputStream = process.getInputStream
-              val isr = new InputStreamReader(is)
-              val br = new BufferedReader(isr)
-              var line: String = br.readLine()
-              while (line != null && !line.trim.contains("state: RUNNING")) {
-                if (line.contains("Exception")) {
-                  logger.error(line)
-                  throw new RuntimeException("could not start spark-submit")
-                }
-                line = br.readLine()
+      val maybeJson = org.json4s.native.JsonMethods.parseOpt(body)
+      val maybeSessionId = maybeJson.flatMap(_.extractOpt[SessionId])
+      maybeSessionId match {
+        case Some(sessionId) =>
+          // connect existing session
+          val session = sessionManager.getSession(sessionId.session_id)
+          session match {
+            case Failure(t) =>
+              InternalServerError ~> errorMsgContentType ~> ResponseString("Failed to get session")
+            case Success(sessionInfo) =>
+              sessionInfo match {
+                case SessionState.NotFound =>
+                  logger.warn("received a query JSON without a usable session_id")
+                  Unauthorized ~> errorMsgContentType ~> ResponseString("Unknown session_id")
+                case SessionState.Registering(key) =>
+                  logger.warn(s"processor for session $key has not registered yet")
+                  ServiceUnavailable ~> errorMsgContentType ~> ResponseString("This session has not been registered. Wait a second.")
+                case SessionState.Ready(host, port, key) =>
+                  logger.info(s"received login request for existing session (${sessionId}) from ${reqSource}")
+                  val sessionIdJson = write(SessionId(sessionId.session_id))
+                  Ok ~> errorMsgContentType ~> ResponseString(sessionIdJson)
               }
-              process.destroy()
-              // TODO: consider to check line is not null here
-              Success(1)
-            }
           }
-        case RunMode.Development(numThreads) =>
-          cmd.update(4, s"local[$numThreads]") // --master
-          cmd.update(6, "run.mode=development") // --conf
-          cmd.insertAll(7, Seq("--conf", s"jubaql.checkpointdir=$checkpointDir"))
-          logger.debug("executing: " + cmd.mkString(" "))
+        case None =>
+          // connect new session
+          val session = sessionManager.createNewSession()
+          session match {
+            case Failure(t) =>
+              InternalServerError ~> errorMsgContentType ~> ResponseString("Failed to create session")
+            case Success((sessionId, key)) =>
+              val callbackUrl = composeCallbackUrl(ipAddress, port, key)
+              val gatewayAddress = s"${ipAddress}:${port}"
 
-          Try {
-            val maybeProcess = Try(runtime.exec(cmd.toArray))
+              val runtime = Runtime.getRuntime
+              val cmd = mutable.ArrayBuffer(f"$sparkDistribution%s/bin/spark-submit",
+                "--class", "us.jubat.jubaql_server.processor.JubaQLProcessor",
+                "--master", "", // set later
+                "--conf", "", // set later
+                "--conf", s"log4j.configuration=file:$tmpLog4jPath",
+                "--name", s"JubaQLProcessor:$gatewayAddress:$sessionId",
+                fatjar,
+                callbackUrl)
+              logger.info(f"starting Spark in run mode $runMode%s (session_id: $sessionId%s)")
+              val divide = runMode match {
+                case RunMode.Production(zookeeper, numExecutors, coresPerExecutor, sparkJar) =>
+                  cmd.update(4, "yarn-cluster") // --master
+                  // When we run the processor on YARN, any options passed in with run.mode
+                  // will be passed to the SparkSubmit class, not the the Spark driver. To
+                  // get the run.mode passed one step further, we use the extraJavaOptions
+                  // variable. It is important to NOT ADD ANY QUOTES HERE or they will be
+                  // double-escaped on their way to the Spark driver and probably never end
+                  // up there.
+                  cmd.update(6, "spark.driver.extraJavaOptions=-Drun.mode=production " +
+                    s"-Djubaql.zookeeper=$zookeeper " +
+                    s"-Djubaql.checkpointdir=$checkpointDir "+
+                    s"-Djubaql.gateway.address=$gatewayAddress " +
+                    s"-Djubaql.processor.sessionId=$sessionId") // --conf
+                  // also specify the location of the Spark jar file, if given
+                  val sparkJarParams = sparkJar match {
+                    case Some(url) => "--conf" :: s"spark.yarn.jar=$url" :: Nil
+                    case _ => Nil
+                  }
+                  cmd.insertAll(9, "--num-executors" :: numExecutors.toString ::
+                    "--executor-cores" :: coresPerExecutor.toString :: sparkJarParams)
+                  logger.debug("executing: " + cmd.mkString(" "))
+                  Try {
+                    val maybeProcess = Try(runtime.exec(cmd.toArray, envpForProcessor))
+                    maybeProcess match {
+                      case Success(_) =>
+                        maybeProcess.flatMap { process =>
+                          // cache spark-submit.log
+                          val logBuffer = new scala.collection.mutable.StringBuilder()
 
-            maybeProcess.flatMap { process =>
-              handleSubProcessOutput(process.getInputStream, System.out)
-              handleSubProcessOutput(process.getErrorStream, System.err)
-              Success(1)
-            }
+                          val sparkProcessFuture = Future {
+                            // NB. which stream we have to use and whether the message we are
+                            // waiting for actually appears, depends on the log4j.xml file
+                            // bundled in the application jar...
+                            val is: InputStream = process.getInputStream
+                            val isr = new InputStreamReader(is)
+                            val br = new BufferedReader(isr)
+                            var line: String = br.readLine()
+                            while (line != null && !line.trim.contains("state: RUNNING")) {
+                              line = br.readLine()
+                              logBuffer.append("\t" + line + Lineseparator)
+                            }
+                            Try(process.exitValue) match {
+                              case Success(returnCode) =>
+                                // process finished => abnormal
+                                throw new RuntimeException("Failed to finish process. returnCode: " + returnCode)
+                              case Failure(t) if (t.isInstanceOf[IllegalThreadStateException] && line.trim.contains("state: RUNNING")) =>
+                                //process still running and state is runnning => normal
+                              case Failure(t) =>
+                                throw new RuntimeException("Failed to spark-submit is not in the runnning state", t)
+                            }
+                          }
+                          Try(Await.result(sparkProcessFuture, Duration(submitTimeout, MILLISECONDS))) match {
+                            case Success(_) =>
+                              //watch spark-submit starting process
+                              handleSubProcess(process, sessionId)
+                              Success(1)
+                            case Failure(t) =>
+                              if (t.isInstanceOf[java.util.concurrent.TimeoutException]) {
+                                logger.error(s"processor did not start within timeout period (${submitTimeout / 1000} seconds)${Lineseparator}spark-submit log : ${Lineseparator}" + logBuffer.toString())
+                              } else {
+                                logger.error(s"${t.getMessage}${Lineseparator}spark-submit log : ${Lineseparator}" + logBuffer.toString())
+                              }
+                              process.destroy()
+                              Failure(t)
+                          }
+                        }
+                      case Failure(e) =>
+                        Failure(e)
+                    }
+                  }
+                case RunMode.Development(numThreads) =>
+                  cmd.update(4, s"local[$numThreads]") // --master
+                  cmd.update(6, "run.mode=development") // --conf
+                  cmd.insertAll(7, Seq("--conf", s"jubaql.checkpointdir=$checkpointDir"))
+                  logger.debug("executing: " + cmd.mkString(" "))
+
+                  Try {
+                    val maybeProcess = Try(runtime.exec(cmd.toArray))
+                    maybeProcess match {
+                      case Success(_) =>
+                        maybeProcess.flatMap { process =>
+                          handleSubProcessOutput(process.getInputStream, System.out)
+                          handleSubProcessOutput(process.getErrorStream, System.err)
+                          Success(1)
+                        }
+                      case Failure(t) =>
+                        Failure(t)
+                    }
+                  }
+                case RunMode.Test =>
+                  // do nothing in test mode.
+                  Success(1)
+              }
+              divide match {
+                case Success(result) =>
+                  result match {
+                    case Failure(e) =>
+                      logger.error(e.getMessage, e)
+                      InternalServerError ~> errorMsgContentType ~> ResponseString("Failed to start Spark\n")
+                    case Success(_) =>
+                      logger.info(f"started Spark with callback URL $callbackUrl%s")
+                      val sessionIdJson = write(SessionId(sessionId))
+                      Ok ~> errorMsgContentType ~> ResponseString(sessionIdJson)
+                    case 1 =>
+                      // test mode result
+                      logger.debug(f"started Spark with callback URL $callbackUrl%s in run.mode=test")
+                      val sessionIdJson = write(SessionId(sessionId))
+                      Ok ~> errorMsgContentType ~> ResponseString(sessionIdJson)
+                  }
+                case Failure(e) =>
+                  logger.error(e.getMessage, e)
+                  InternalServerError ~> errorMsgContentType ~> ResponseString("Failed to start Spark\n")
+              }
           }
-        case RunMode.Test =>
-          // do nothing in test mode.
-          Success(1)
-      }
-      divide match {
-        case Success(_) =>
-          logger.info(f"started Spark with callback URL $callbackUrl%s")
-          val sessionIdJson = write(SessionId(sessionId))
-          Ok ~> errorMsgContentType ~> ResponseString(sessionIdJson)
-        case Failure(e) =>
-          logger.error(e.getMessage)
-          InternalServerError ~> errorMsgContentType ~> ResponseString("Failed to start Spark\n")
+
       }
 
     case req@POST(Path("/jubaql")) =>
       // TODO: treat very long input
       val body = readAllFromReader(req.reader)
       val reqSource = req.remoteAddr
-      logger.info(f"received HTTP request at /jubaql from $reqSource%s with body: $body%s")
+      logger.debug(f"received HTTP request at /jubaql from $reqSource%s with body: $body%s")
       val maybeJson = org.json4s.native.JsonMethods.parseOpt(body)
       val maybeQuery = maybeJson.flatMap(_.extractOpt[Query])
       maybeQuery match {
@@ -210,43 +304,36 @@ class GatewayPlan(ipAddress: String, port: Int,
           logger.warn("received an unacceptable JSON query")
           BadRequest ~> errorMsgContentType ~> ResponseString("Unacceptable JSON")
         case Some(query) =>
-          var maybeKey: Option[String] = None
-          var maybeLoc: Option[(String, Int)] = None
-          session2key.synchronized {
-            maybeKey = session2key.get(query.session_id)
-            maybeLoc = session2loc.get(query.session_id)
-          }
-          (maybeKey, maybeLoc) match {
-            case (None, None) =>
-              logger.warn("received a query JSON without a usable session_id")
-              Unauthorized ~> errorMsgContentType ~> ResponseString("Unknown session_id")
-            case (None, Some(loc)) =>
-              logger.error("inconsistent data in this gateway server")
-              InternalServerError ~> errorMsgContentType ~> ResponseString("Inconsistent data")
-            case (Some(key), None) =>
-              logger.warn(s"processor for session $key has not registered yet")
-              ServiceUnavailable ~> errorMsgContentType ~>
-                ResponseString("This session has not been registered. Wait a second.")
-            case (Some(key), Some(loc)) =>
-              // TODO: check forward query
-              val (host, port) = loc
+          val session = sessionManager.getSession(query.session_id)
+          session match {
+            case Failure(t) =>
+              InternalServerError ~> errorMsgContentType ~> ResponseString("Failed to get session")
+            case Success(sessionInfo) =>
+              sessionInfo match {
+                case SessionState.NotFound =>
+                  logger.warn("received a query JSON without a usable session_id")
+                  Unauthorized ~> errorMsgContentType ~> ResponseString("Unknown session_id")
+                case SessionState.Registering(key) =>
+                  logger.warn(s"processor for session $key has not registered yet")
+                  ServiceUnavailable ~> errorMsgContentType ~> ResponseString("This session has not been registered. Wait a second.")
+                case SessionState.Ready(host, port, key) =>
+                  val queryJson = write(QueryToProcessor(query.query)).toString
 
-              val queryJson = write(QueryToProcessor(query.query)).toString
+                  val url = :/(host, port) / "jubaql"
+                  val req = Http((url.POST << queryJson) > (x => x))
 
-              val url = :/(host, port) / "jubaql"
-              val req = Http((url.POST << queryJson) > (x => x))
-
-              logger.debug(f"forward query to processor ($host%s:$port%d)")
-              req.either.apply() match {
-                case Left(error) =>
-                  logger.error("failed to send request to processor [" + error.getMessage + "]")
-                  BadGateway ~> errorMsgContentType ~> ResponseString("Bad gateway")
-                case Right(result) =>
-                  val statusCode = result.getStatusCode
-                  val responseBody = result.getResponseBody
-                  val contentType = Option(result.getContentType).getOrElse("text/plain; charset=utf-8")
-                  logger.debug(f"got result from processor [$statusCode%d: $responseBody%s]")
-                  Status(statusCode) ~> ContentType(contentType) ~> ResponseString(responseBody)
+                  logger.debug(f"forward query to processor ($host%s:$port%d)")
+                  req.either.apply() match {
+                    case Left(error) =>
+                      logger.error("failed to send request to processor [" + error.getMessage + "]")
+                      BadGateway ~> errorMsgContentType ~> ResponseString("Bad gateway")
+                    case Right(result) =>
+                      val statusCode = result.getStatusCode
+                      val responseBody = result.getResponseBody
+                      val contentType = Option(result.getContentType).getOrElse("text/plain; charset=utf-8")
+                      logger.debug(f"got result from processor [$statusCode%d: $responseBody%s]")
+                      Status(statusCode) ~> ContentType(contentType) ~> ResponseString(responseBody)
+                  }
               }
           }
       }
@@ -260,12 +347,13 @@ class GatewayPlan(ipAddress: String, port: Int,
       val maybeUnregister = maybeJson.flatMap(_.extractOpt[Unregister]).
         filter(_.action == "unregister")
 
-      if (!maybeRegister.isEmpty)
+      if (!maybeRegister.isEmpty) {
         logger.info(f"start registration (key: $key%s)")
-      else if (!maybeUnregister.isEmpty)
+      } else if (!maybeUnregister.isEmpty) {
         logger.info(f"start unregistration (key: $key%s)")
-      else
+      } else {
         logger.info(f"start registration or unregistration (key: $key%s)")
+      }
 
       if (maybeJson.isEmpty) {
         logger.warn("received query not in JSON format")
@@ -274,31 +362,31 @@ class GatewayPlan(ipAddress: String, port: Int,
         logger.warn("received unacceptable JSON query")
         BadRequest ~> errorMsgContentType ~> ResponseString("Unacceptable JSON")
       } else {
-        session2key.synchronized {
-          val maybeSessionId = key2session.get(key)
-          if (!maybeRegister.isEmpty) { // register
-            val register = maybeRegister.get
-            val (ip, port) = (register.ip, register.port)
-            logger.debug(f"registering $ip%s:$port%d")
-            maybeSessionId match {
-              case None =>
-                logger.error("attempted to register unknown key")
-                Unauthorized ~> errorMsgContentType ~> ResponseString("Unknown key")
-              case Some(sessionId) =>
-                session2loc += (sessionId -> (ip, port))
-                Ok ~> errorMsgContentType ~> ResponseString("Successfully registered")
-            }
-          } else { // unregister
-            logger.debug("unregistering")
-            maybeSessionId match {
-              case Some(sessionId) => // unregistering an existent key
-                session2key -= sessionId
-                key2session -= key
-                session2loc -= sessionId
-              case _ => // unregistering a nonexistent key
-                ()
-            }
-            Ok ~> errorMsgContentType ~> ResponseString("Successfully unregistered")
+        if (!maybeRegister.isEmpty) { // register
+          val register = maybeRegister.get
+          val (ip, port) = (register.ip, register.port)
+          logger.debug(f"registering $ip%s:$port%d")
+          val result = sessionManager.attachProcessorToSession(ip, port, key)
+          result match {
+            case Failure(t) =>
+              InternalServerError ~> errorMsgContentType ~> ResponseString(s"Failed to register key : ${key}")
+            case Success(sessionId) =>
+              logger.info(s"registered session. sessionId : $sessionId")
+              Ok ~> errorMsgContentType ~> ResponseString("Successfully registered")
+          }
+        } else { // unregister
+          logger.debug("unregistering")
+          val result = sessionManager.deleteSessionByKey(key)
+          result match {
+            case Failure(t) =>
+              InternalServerError ~> errorMsgContentType ~> ResponseString(s"Failed to unregister key : ${key}")
+            case Success((sessionId, key)) =>
+              if (sessionId != null) {
+                logger.info(s"unregistered session. sessionId: ${sessionId}")
+              } else {
+                logger.info(s"already delete session. key: ${key}")
+              }
+              Ok ~> errorMsgContentType ~> ResponseString("Successfully unregistered")
           }
         }
       }
@@ -315,6 +403,12 @@ class GatewayPlan(ipAddress: String, port: Int,
     thread.start()
   }
 
+  private def handleSubProcess(process: Process, sessionId: String): Unit = {
+    val thread = new SubProcessHandlerThread(process, sessionId, this, logger)
+    thread.setDaemon(true)
+    thread.start()
+  }
+
   private def readAllFromReader(reader: java.io.Reader):String = {
     val sb = new StringBuffer()
     val buffer = Array[Char](1024)
@@ -325,27 +419,15 @@ class GatewayPlan(ipAddress: String, port: Int,
     }
     sb.toString
   }
-}
 
-// An alphanumeric string generator.
-object Alphanumeric {
-  val random = new Random()
-  val chars = "0123456789abcdefghijklmnopqrstuvwxyz"
-
-  def generate(length: Int): String = {
-    val ret = new Array[Char](length)
-    this.synchronized {
-      for (i <- 0 until ret.length) {
-        ret(i) = chars(random.nextInt(chars.length))
-      }
-    }
-    new String(ret)
+  def close():Unit = {
+    sessionManager.close()
   }
 }
 
 private class SubProcessOutputHandlerThread(in: InputStream,
                                             out: PrintStream,
-                                            logger: com.typesafe.scalalogging.Logger) extends Thread {
+                                            logger: com.typesafe.scalalogging.slf4j.Logger) extends Thread {
   override def run(): Unit = {
     val reader = new BufferedReader(new InputStreamReader(in))
     try {
@@ -356,10 +438,54 @@ private class SubProcessOutputHandlerThread(in: InputStream,
       }
     } catch {
       case e: IOException =>
-        logger.warn("caught IOException in subprocess handler")
+        logger.warn("caught IOException in subprocess handler", e)
         ()
     }
     // Never close out here.
+  }
+}
+
+private class SubProcessHandlerThread(process: Process, sessionId: String, parent: GatewayPlan, logger: com.typesafe.scalalogging.slf4j.Logger) extends Thread {
+  override def run(): Unit = {
+    try {
+      process.waitFor()
+      Try(process.exitValue) match {
+        case Success(returnCode) =>
+          if (returnCode == 0) {
+            logger.info("Finished spark-submit")
+          } else {
+            logger.error(f"Failed to spark-submit. returnCode: $returnCode%s")
+          }
+        case Failure(e) =>
+          logger.error("Failed to spark-submit", e)
+      }
+    } catch {
+      case e: Exception =>
+        logger.error("caught Exception in spark-submit error handler", e)
+    } finally {
+      try {
+        parent.sessionManager.getSession(sessionId) match {
+          case Success(state) =>
+            state match {
+              case SessionState.Ready(_, _, _) | SessionState.Registering(_) =>
+                parent.sessionManager.deleteSessionById(sessionId) match {
+                  case Success((sessionId, key)) =>
+                    logger.debug(s"Finished terminate process. sessionId: ${sessionId}")
+                  case Failure(t) =>
+                    throw t
+                }
+              case _ =>
+                logger.debug(s"Terminate process is not required. sessionId: ${sessionId}")
+            }
+          case Failure(t) =>
+            throw t
+        }
+      } catch {
+        case e: Exception =>
+          logger.error(s"Failed to terminate process. sessionId: ${sessionId}", e)
+      }
+      process.destroy()
+    }
   }
 }
 

--- a/gateway/src/main/scala/us/jubat/jubaql_server/gateway/SessionManager.scala
+++ b/gateway/src/main/scala/us/jubat/jubaql_server/gateway/SessionManager.scala
@@ -1,0 +1,492 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2015 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+package us.jubat.jubaql_server.gateway
+
+import scala.collection.mutable
+import scala.collection.mutable._
+import scala.util.Random
+import org.json4s._
+import org.json4s.native.JsonMethods._
+import com.typesafe.scalalogging.slf4j.LazyLogging
+import scala.util.{Try, Success, Failure}
+
+/**
+ * Session Management Class
+ */
+class SessionManager(gatewayId: String, sessionStore: SessionStore = new NonPersistentStore) extends LazyLogging {
+  implicit val formats = DefaultFormats
+
+  logger.info(s"Use SessionStore: ${sessionStore.getClass}")
+
+  // key = sessionId, value = keyInfo
+  val session2key: mutable.Map[String, String] = new mutable.HashMap()
+  // key = keyInfo, value = sessionId
+  // key: identification required for registration / unregistration
+  val key2session: mutable.Map[String, String] = new mutable.HashMap()
+  // key = sessionId, vale = Processor's connectionInfo(host, port)
+  val session2loc: mutable.Map[String, (String, Int)] = new mutable.HashMap()
+
+  // initialize session store(specific processing)
+  sessionStore.registerGateway(gatewayId)
+
+  // initialize cache from session store
+  initCache()
+
+  // --- session controller method ---
+  /**
+   * initialize cache from session store
+   */
+  def initCache(): Unit = {
+    val sessionMap = sessionStore.getAllSessions(gatewayId)
+    session2key.synchronized {
+      for ((sessionId, sessionInfo) <- sessionMap) {
+        sessionInfo match {
+          case completeSesion: SessionState.Ready =>
+            session2key += sessionId -> completeSesion.key
+            key2session += completeSesion.key -> sessionId
+            session2loc += sessionId -> (completeSesion.host, completeSesion.port)
+            sessionStore.addDeleteListener(gatewayId, sessionId, deleteFunction)
+          case registeringSession: SessionState.Registering =>
+            logger.debug(s"Registering session not add to cache. session: ${sessionId}")
+          case _ =>
+            logger.debug(s"Invalid session. exclude session: ${sessionId}")
+        }
+      }
+    }
+  }
+
+  /**
+   * create new session
+   * @return resultCreateSession(session ID and registration key)
+   */
+  def createNewSession(): Try[(String, String)] = {
+    var lockObj: SessionLock = null
+    val result = Try {
+      lockObj = lock()
+      val (sessionId, key) = createId()
+      sessionStore.preregisterSession(gatewayId, sessionId, key)
+      session2key.synchronized {
+        session2key += (sessionId -> key)
+        key2session += (key -> sessionId)
+      }
+      logger.debug(s"created session. sessionId: ${sessionId}")
+      (sessionId, key)
+    }
+    unlock(lockObj)
+    result
+  }
+
+  /**
+   * get Session
+   * if not found in cache, contact to session store
+   * @param sessionId: sessionId
+   * @return SessionInformation (processor's host, processor's port, regstrationKey)
+   */
+  def getSession(sessionId: String): Try[SessionState] = {
+    Try {
+      val cacheSession: SessionState = getSessionFromCache(sessionId)
+      cacheSession match {
+        case completeSession: SessionState.Ready => completeSession
+        case registeringSession: SessionState.Registering => registeringSession
+        case SessionState.NotFound =>
+          logger.debug(s"session not found from cache. sessionId: ${sessionId}")
+          // session not found in cache, contact session store.
+          val storeSession = sessionStore.getSession(gatewayId, sessionId)
+          storeSession match {
+            case SessionState.NotFound => storeSession
+            case SessionState.Inconsistent =>
+              throw new Exception(s"Inconsistent data. sessionId: ${sessionId}")
+            case completeSession: SessionState.Ready =>
+              val host = completeSession.host
+              val port = completeSession.port
+              val key = completeSession.key
+              sessionStore.addDeleteListener(gatewayId, sessionId, deleteFunction)
+              session2key.synchronized {
+                session2key += sessionId -> key
+                key2session += key -> sessionId
+                session2loc += sessionId -> (host, port)
+              }
+              completeSession
+            case registeringSession: SessionState.Registering =>
+              registeringSession
+          }
+      }
+    }
+  }
+
+  /**
+   * get session from cache
+   * @param sessionId session ID
+   * @return session information
+   */
+  def getSessionFromCache(sessionId: String): SessionState = {
+    session2key.get(sessionId) match {
+      case Some(key) =>
+        session2loc.get(sessionId) match {
+          case Some(loc) =>
+            if (key != null) {
+              SessionState.Ready(loc._1, loc._2, key)
+            } else {
+              throw new Exception(s"Inconsistent data. sessionId: ${sessionId}")
+            }
+          case None =>
+            // not yet registered sessionId.
+            SessionState.Registering(key)
+        }
+      case None =>
+        SessionState.NotFound
+    }
+  }
+
+  /**
+   * attach Processor Information to session
+   * @param host Processor's host
+   * @param port Processor's port
+   * @param key registration key
+   * @return attachResult
+   */
+  def attachProcessorToSession(host: String, port: Int, key: String): Try[String] = {
+    var lockObj: SessionLock = null
+    val result = Try {
+      val sessionId = key2session.get(key) match {
+        case Some(sessionId) => sessionId
+        case None => throw new Exception(s"non exist sessionId. key: ${key}")
+      }
+      lockObj = lock()
+      sessionStore.registerSession(gatewayId, sessionId, host, port, key)
+      sessionStore.addDeleteListener(gatewayId, sessionId, deleteFunction)
+      session2key.synchronized {
+        session2loc += (sessionId -> (host, port))
+      }
+      logger.debug(s"attached session. sessionId: ${sessionId}")
+      sessionId
+    }
+    unlock(lockObj)
+    result
+  }
+
+  /**
+   * delete Session by registration key
+   * @param key registration key
+   * @return deleteResult(sessionId, key)
+   */
+  def deleteSessionByKey(key: String): Try[(String, String)] = {
+    Try {
+      key2session.get(key) match {
+        case Some(sessionId) =>
+          deleteSessionById(sessionId) match {
+            case Success((deleteSessionId, deleteKey)) =>
+              (deleteSessionId, deleteKey)
+            case Failure(t) =>
+              throw t
+          }
+        case None =>
+          logger.debug(s"non exist sessionId. key: ${key}")
+          (null, key)
+      }
+    }
+  }
+
+  /**
+   * delete Session by sessionId
+   * @param sessionId session ID
+   * @return deleteResult(sessionId, key)
+   */
+  def deleteSessionById(sessionId: String): Try[(String, String)] = {
+    var lockObj: SessionLock = null
+    val result = Try {
+      lockObj = lock()
+      sessionStore.deleteSession(gatewayId, sessionId)
+      session2key.synchronized {
+        val key = session2key.get(sessionId) match {
+          case Some(key) =>
+            key2session -= key
+            key
+          case None => null
+        }
+        session2key -= sessionId
+        session2loc -= sessionId
+        logger.debug(s"deleted session. sessionId: ${sessionId}")
+        (sessionId, key)
+      }
+
+    }
+    unlock(lockObj)
+    result
+  }
+
+  /**
+   * gateway session lock
+   * @return Lock Object
+   */
+  def lock(): SessionLock = {
+    val lock = sessionStore.lock(gatewayId)
+    logger.debug(s"locked: $gatewayId")
+    lock
+  }
+
+  /**
+   * gateway session unlock
+   * @param lock Lock Object
+   */
+  def unlock(lock: SessionLock): Unit = {
+    if (lock != null) {
+      try {
+        sessionStore.unlock(lock)
+        logger.debug(s"unlocked: gatewayId = $gatewayId")
+      } catch {
+        case e: Exception =>
+          logger.error("failed to unlock.", e)
+      }
+    } else {
+      logger.debug(s"not lock. gatewayId = $gatewayId")
+    }
+  }
+
+  /**
+   * generate sessionId and key
+   * @return (sessionId, registrationKey)
+   */
+  def createId(): (String, String) = {
+    session2key.synchronized {
+      var sessionId = ""
+      var key = ""
+
+      do {
+        sessionId = Alphanumeric.generate(20)
+      } while (session2key.get(sessionId) != None)
+      do {
+        key = Alphanumeric.generate(20)
+      } while (key2session.get(key) != None)
+      (sessionId, key)
+    }
+  }
+
+  /**
+   * delete session in cache. called by delete listeners.
+   * @param sessionId session ID
+   */
+  def deleteFunction(sessionId: String): Unit = {
+    logger.debug(s"delete session from cache. sessionId: ${sessionId}")
+    session2key.synchronized {
+      val keyOpt = session2key.get(sessionId)
+      keyOpt match {
+        case Some(key) => key2session -= key
+        case None => //Nothing
+      }
+      session2key -= sessionId
+      session2loc -= sessionId
+    }
+  }
+
+  /**
+   * get session from store
+   * @param sessionId session ID
+   * @return session information
+   */
+  def getSessionFromStore(sessionId: String): SessionState = {
+    sessionStore.getSession(gatewayId, sessionId)
+  }
+
+  /**
+   * close
+   */
+  def close(): Unit = {
+    sessionStore.close()
+  }
+}
+
+/**
+ *  An alphanumeric string generator.
+ */
+object Alphanumeric {
+  val random = new Random(new java.security.SecureRandom())
+  val chars = "0123456789abcdefghijklmnopqrstuvwxyz"
+
+  /**
+   * generate ID
+   * @param length generated ID length
+   */
+  def generate(length: Int): String = {
+    val ret = new Array[Char](length)
+    this.synchronized {
+      for (i <- 0 until ret.length) {
+        ret(i) = chars(random.nextInt(chars.length))
+      }
+    }
+
+    new String(ret)
+  }
+}
+
+/**
+ * Session Store Interface
+ */
+trait SessionStore {
+  implicit val formats = DefaultFormats
+
+  /**
+   * get All Session by gatewayId
+   * @param gatewayId gateway ID
+   * @return SessionInformation Map(key   = sessionId, value = SessionState)
+   */
+  def getAllSessions(gatewayId: String): Map[String, SessionState]
+
+  /**
+   * get Session
+   * if not found in cache, contact to session store
+   * @param gatewayId gateway ID
+   * @param sessionId session ID
+   * @return SessionState
+   */
+  def getSession(gatewayId: String, sessionId: String): SessionState
+
+  /**
+   * register SessionId to session store
+   * @param gatewayId gateway ID
+   * @param sessionId session ID
+   * @param key registration key
+   */
+  def preregisterSession(gatewayId: String, sessionId: String, key: String): Unit
+
+  /**
+   * register Session to session store
+   * @param gatewayId gateway ID
+   * @param sessionId session ID
+   * @param host Processor's host
+   * @param port Processor's port
+   * @param key registration key
+   */
+  def registerSession(gatewayId: String, sessionId: String, host: String, port: Int, key: String): Unit
+
+  /**
+   * delete Session
+   * @param gatewayId gateway ID
+   * @param sessionId session Id
+   */
+  def deleteSession(gatewayId: String, sessionId: String): Unit
+
+  /**
+   * gateway session lock
+   * @param gatewayId gateway ID
+   * @return Lock Object
+   */
+  def lock(gatewayId: String): SessionLock
+
+  /**
+   * gateway session unlock
+   * @param lock Lock Object
+   */
+  def unlock(lock: SessionLock): Unit
+
+  /**
+   * register delete listener
+   * @param gatewayId gateway Id
+   * @param sessionId session Id
+   * @param deleteFunction delete-event trigger, call function
+   */
+  def addDeleteListener(gatewayId: String, sessionId: String, deleteFunction: Function1[String, Unit] = null): Unit
+
+  /**
+   * initialize session store
+   * @param gatewayId gateway Id
+   */
+  def registerGateway(gatewayId: String): Unit
+
+  /**
+   * close
+   */
+  def close(): Unit
+
+  // --- utility method ---
+  /**
+   * extract Session Information for jsonString
+   * @param jsonString
+   * @return SessionInfo
+   */
+  def extractSessionInfo(jsonString: String): SessionState = {
+    try {
+      val jsonData = parse(jsonString)
+      if (jsonData != JNothing && jsonData.children.length > 0) {
+        val host = (jsonData \ "host") match {
+          case JNothing => null
+          case value: JValue => value.extract[String]
+        }
+        val port = (jsonData \ "port") match {
+          case JNothing => null
+          case value: JValue => value.extract[String]
+        }
+        val key = (jsonData \ "key") match {
+          case JNothing => null
+          case value: JValue => value.extract[String]
+        }
+        if (host == null && port == null && key == null) {
+          SessionState.NotFound
+        } else if (host == null && port == null && key != null) {
+          SessionState.Registering(key)
+        } else if (host != null && port != null && key != null) {
+          SessionState.Ready(host, port.toInt, key)
+        } else {
+          SessionState.Inconsistent
+        }
+      } else {
+        SessionState.NotFound
+      }
+    } catch {
+      case e: Throwable =>
+        throw e
+    }
+  }
+}
+
+/**
+ * Session Lock Object
+ */
+class SessionLock(lock: Any) {
+  val lockObject = lock
+}
+
+/**
+ * SessionStore for non-persist
+ */
+class NonPersistentStore extends SessionStore {
+  override def getAllSessions(gatewayId: String): Map[String, SessionState] = Map.empty[String, SessionState]
+  override def getSession(gatewayId: String, sessionId: String): SessionState = SessionState.NotFound
+  override def preregisterSession(gatewayId: String, sessionId: String, key: String): Unit = {}
+  override def registerSession(gatewayId: String, sessionId: String, host: String, port: Int, key: String): Unit = {}
+  override def deleteSession(gatewayId: String, sessionId: String): Unit = {}
+  override def lock(gatewayId: String): SessionLock = { null }
+  override def unlock(lock: SessionLock): Unit = {}
+  override def addDeleteListener(gatewayId: String, sessionId: String, deleteFunction: Function1[String, Unit] = null): Unit = {}
+  override def registerGateway(gatewayId: String): Unit = {}
+  override def close(): Unit = {}
+}
+
+/**
+ * SessionInfo
+ */
+trait SessionState
+
+object SessionState {
+  // Session ready
+  case class Ready(host: String, port: Int, key: String) extends SessionState
+  // Registering yet
+  case class Registering(key: String) extends SessionState
+  // Session Inconsistent
+  case object Inconsistent extends SessionState
+  // Unknown session
+  case object NotFound extends SessionState
+}

--- a/gateway/src/main/scala/us/jubat/jubaql_server/gateway/ZookeeperStore.scala
+++ b/gateway/src/main/scala/us/jubat/jubaql_server/gateway/ZookeeperStore.scala
@@ -1,0 +1,257 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2015 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+package us.jubat.jubaql_server.gateway
+
+import com.typesafe.scalalogging.slf4j.LazyLogging
+import scala.collection.mutable
+import scala.collection.mutable._
+import org.apache.curator._
+import org.apache.curator.retry._
+import org.apache.curator.framework._
+import org.apache.curator.framework.recipes.locks._
+import collection.JavaConversions._
+import org.apache.zookeeper.KeeperException
+import org.apache.zookeeper.KeeperException.NoNodeException
+import org.apache.curator.framework.api.CuratorListener
+import org.apache.curator.framework.api.CuratorEvent
+import org.apache.zookeeper.Watcher
+import org.apache.curator.framework.listen.ListenerContainer
+import java.util.concurrent.TimeUnit
+
+/**
+ * ZooKeeper Store Class
+ */
+class ZookeeperStore extends SessionStore with LazyLogging {
+
+  val zkJubaQLPath: String = "/jubaql"
+  val zkSessionPath: String = "/jubaql/session"
+
+  val lockNodeName = "locks"
+  val leasesNodeName = "leases"
+  //lock keep time(unit: seconds)
+  val lockTimeout: Long = 300
+  // retry sleep time(unit: ms)
+  val retrySleepTimeMs: Int = 1000
+  val retryCount: Int = 1
+
+  val zookeeperString: String = scala.util.Properties.propOrElse("jubaql.zookeeper", "")
+  val retryPolicy: RetryPolicy = new RetryNTimes(retryCount, retrySleepTimeMs)
+
+  logger.info(s"connecting to ZooKeeper : ${zookeeperString}")
+  val zookeeperClient: CuratorFramework = CuratorFrameworkFactory.newClient(zookeeperString, retryPolicy)
+
+  zookeeperClient.start()
+  if (!zookeeperClient.getZookeeperClient.blockUntilConnectedOrTimedOut) {
+    zookeeperClient.close()
+    logger.error(s"zookeeper connection timeout. zookeeper: ${zookeeperString}")
+    throw new Exception("failed to connected zookeeper")
+  }
+  logger.info(s"connected to ZooKeeper : ${zookeeperString}")
+
+  override def getAllSessions(gatewayId: String): Map[String, SessionState] = {
+    var result = Map.empty[String, SessionState]
+    try {
+      val isExist = zookeeperClient.checkExists().forPath(s"${zkSessionPath}/${gatewayId}")
+      if (isExist != null) {
+        val sessionIdList = zookeeperClient.getChildren.forPath(s"${zkSessionPath}/${gatewayId}")
+        for (sessionId <- sessionIdList) {
+          val sessionInfo = getSession(gatewayId, sessionId)
+          result += sessionId -> sessionInfo
+        }
+      } else {
+        logger.debug(s"non exist node. gatewayId: ${gatewayId}")
+      }
+    } catch {
+      case e: Exception =>
+        val errorMessage = "failed to get all session."
+        logger.error(errorMessage, e)
+        throw new Exception(errorMessage, e)
+    }
+    return result
+  }
+
+  override def getSession(gatewayId: String, sessionId: String): SessionState = {
+    try {
+      val sessionByteArray = zookeeperClient.getData().forPath(s"${zkSessionPath}/${gatewayId}/${sessionId}")
+      val sessionJsonString = new String(sessionByteArray, "UTF-8")
+      extractSessionInfo(sessionJsonString)
+    } catch {
+      case e: NoNodeException =>
+        logger.debug(s"not found session. sesionId: ${sessionId}")
+        SessionState.NotFound
+      case e: Exception =>
+        val errorMessage = s"failed to get session. sessionId: ${sessionId}"
+        logger.error(errorMessage, e)
+        throw new Exception(errorMessage, e)
+    }
+  }
+
+  override def preregisterSession(gatewayId: String, sessionId: String, key: String): Unit = {
+    try {
+      val isExists = zookeeperClient.checkExists().forPath(s"${zkSessionPath}/${gatewayId}/${sessionId}")
+      if (isExists == null) {
+        zookeeperClient.create().forPath(s"${zkSessionPath}/${gatewayId}/${sessionId}", s"""{"key":"$key"}""".getBytes("UTF-8"))
+      } else {
+        throw new IllegalStateException(s"already exists session. sessionId: ${sessionId}")
+      }
+    } catch {
+      case e: Exception =>
+        val errorMessage = s"failed to pre-register session. sessionId: ${sessionId}"
+        logger.error(errorMessage, e)
+        throw new Exception(errorMessage, e)
+    }
+  }
+
+  override def registerSession(gatewayId: String, sessionId: String, host: String, port: Int, key: String): Unit = {
+    try {
+      val isExists = zookeeperClient.checkExists().forPath(s"${zkSessionPath}/${gatewayId}/${sessionId}")
+      if (isExists != null) {
+        val currentSession = getSession(gatewayId, sessionId)
+        if (currentSession.isInstanceOf[SessionState.Registering]) {
+          zookeeperClient.setData().forPath(s"${zkSessionPath}/${gatewayId}/${sessionId}", s"""{"host":"$host","port":$port,"key":"$key"}""".getBytes("UTF-8"))
+        } else {
+          throw new IllegalStateException(s"illegal session state. sessionId: ${sessionId}, state: ${currentSession}")
+        }
+      } else {
+        throw new IllegalStateException(s"non exists session. sessionId: ${sessionId}")
+      }
+    } catch {
+      case e: Exception =>
+        val errorMessage = s"failed to register session. sessionId: ${sessionId}"
+        logger.error(errorMessage, e)
+        throw new Exception(errorMessage, e)
+    }
+  }
+
+  override def deleteSession(gatewayId: String, sessionId: String): Unit = {
+    try {
+      zookeeperClient.delete().forPath(s"${zkSessionPath}/${gatewayId}/${sessionId}")
+    } catch {
+      case e: NoNodeException => logger.warn(s"No exist Node. sessionId : $sessionId")
+      case e: Exception =>
+        val errorMessage = s"failed to delete session. sessionId: ${sessionId}"
+        logger.error(errorMessage, e)
+        throw new Exception(errorMessage, e)
+    }
+  }
+
+  override def lock(gatewayId: String): SessionLock = {
+    val mutex: InterProcessSemaphoreMutex = try {
+      val mutex = new InterProcessSemaphoreMutex(zookeeperClient, s"${zkSessionPath}/${gatewayId}")
+      mutex.acquire(lockTimeout, TimeUnit.SECONDS)
+      mutex
+    } catch {
+      case e: Exception =>
+        val errorMessage = s"failed to create lock object. gatewayId: ${gatewayId}"
+        logger.error(errorMessage, e)
+        throw new Exception(errorMessage, e)
+    }
+    new SessionLock(mutex)
+  }
+
+  override def unlock(lock: SessionLock): Unit = {
+    if (lock != null) {
+      val mutex = lock.lockObject
+      if (mutex != null && mutex.isInstanceOf[InterProcessSemaphoreMutex]) {
+        try {
+          mutex.asInstanceOf[InterProcessSemaphoreMutex].release()
+        } catch {
+          case e: Exception =>
+            val errorMessage = "failed to unlock"
+            logger.error(errorMessage, e)
+            throw new Exception(errorMessage, e)
+        }
+      } else {
+        val errorMessage = if (mutex != null) {
+          s"failed to unlock. illegal lock object: ${mutex.getClass()}"
+        } else {
+          "failed to unlock. lock object: null"
+        }
+        logger.error(errorMessage)
+        throw new Exception(errorMessage)
+      }
+    } else {
+      val errorMessage = "failed to unlock. session lock: null"
+      logger.error(errorMessage)
+      throw new Exception(errorMessage)
+    }
+  }
+
+  override def addDeleteListener(gatewayId: String, sessionId: String, deleteFunction: Function1[String, Unit]): Unit = {
+    try {
+      zookeeperClient.synchronized {
+        val listenerSize = if (zookeeperClient.getCuratorListenable.isInstanceOf[ListenerContainer[CuratorListener]]) {
+          val container = zookeeperClient.getCuratorListenable.asInstanceOf[ListenerContainer[CuratorListener]]
+          container.size()
+        } else {
+          throw new Exception(s"invalid listener class. class: ${zookeeperClient.getCuratorListenable.getClass}")
+        }
+        if (sessionId != lockNodeName && sessionId != leasesNodeName) {
+          if (listenerSize == 0) {
+            val listener = new CuratorListener() {
+              override def eventReceived(client: CuratorFramework, event: CuratorEvent): Unit = {
+                if (event.getWatchedEvent != null && event.getWatchedEvent.getType == Watcher.Event.EventType.NodeDeleted) {
+                  val deletedNodePath = event.getPath
+                  val deletedSessionID = deletedNodePath.substring(deletedNodePath.lastIndexOf("/") + 1, deletedNodePath.length)
+                  deleteFunction(deletedSessionID)
+                }
+              }
+            }
+            zookeeperClient.getCuratorListenable.addListener(listener)
+          }
+          zookeeperClient.getChildren.watched().forPath(s"${zkSessionPath}/${gatewayId}/${sessionId}")
+        } else {
+          logger.debug(s"not add listener. exclude sessionId: ${sessionId}")
+        }
+      }
+    } catch {
+      case e: Exception =>
+        val errorMessage = s"failed to add delete listener. sessionId: ${sessionId}"
+        logger.error(errorMessage, e)
+        throw new Exception(errorMessage, e)
+    }
+  }
+
+  override def registerGateway(gatewayId: String): Unit = {
+    try {
+      if (zookeeperClient.checkExists().forPath(zkJubaQLPath) == null) {
+        zookeeperClient.create().forPath(zkJubaQLPath, new Array[Byte](0))
+      }
+      if (zookeeperClient.checkExists().forPath(zkSessionPath) == null) {
+        zookeeperClient.create().forPath(zkSessionPath, new Array[Byte](0))
+      }
+      if (zookeeperClient.checkExists().forPath(s"${zkSessionPath}/${gatewayId}") == null) {
+        zookeeperClient.create().forPath(s"${zkSessionPath}/${gatewayId}", new Array[Byte](0))
+      }
+    } catch {
+      case e: Exception =>
+        val errorMessage = s"failed to registerGateway. gatewayId: ${gatewayId}"
+        logger.error(errorMessage, e)
+        throw new Exception(errorMessage, e)
+    }
+  }
+
+  override def close(): Unit = {
+    try {
+      zookeeperClient.close()
+      logger.info("zookeeperClient closed")
+    } catch {
+      case e: Exception =>
+        val errorMessage = s"failed to close."
+        logger.error(errorMessage, e)
+    }
+  }
+}

--- a/gateway/src/test/java/DummySparkSubmit.java
+++ b/gateway/src/test/java/DummySparkSubmit.java
@@ -1,0 +1,132 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+public class DummySparkSubmit {
+	public static void main(String[] args) throws Exception {
+        String url = "";
+        boolean isTimeout = false;
+        boolean isReturn = false;
+        boolean isAfter = false;
+        boolean isAfterFailed = false;
+        boolean isException = false;
+
+		for (String arg : args) {
+			System.out.println(arg);
+            if(arg.startsWith("http://")) {
+              url = arg;
+            } else if (arg.contains("jubaql.checkpointdir")) {
+            	if (arg.contains("timeout")) {
+            		isTimeout = true;
+            	} else if (arg.contains("return")) {
+            		isReturn = true;
+            	} else if (arg.contains("after")) {
+            		isAfter = true;
+            	} else if (arg.contains("afterFailed")) {
+            		isAfterFailed = true;
+            	}else if (arg.contains("exception")) {
+            		isException = true;
+            	}
+            }
+		}
+		if (isTimeout) {
+			long startTime = System.currentTimeMillis();
+			while (System.currentTimeMillis() - startTime < 30000) {
+				try {
+					Thread.sleep(1000);
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+				System.out.println("state: ACCEPTED");
+			}
+		} else if (isReturn) {
+			long startTime = System.currentTimeMillis();
+			while (System.currentTimeMillis() - startTime < 5000) {
+				try {
+					Thread.sleep(1000);
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+				System.out.println("state: ACCEPTED");
+			}
+		} else if (isAfter) {
+			Thread.sleep(1000);
+			System.out.println("state: ACCEPTED");
+			Thread.sleep(1000);
+			System.out.println("state: RUNNING");
+			sendRegistRequest(url);
+			Thread.sleep(5000);
+			System.out.println("[Error] Exception: xxxxxxxxxxxx");
+		} else if (isAfterFailed) {
+			Thread.sleep(1000);
+			System.out.println("state: ACCEPTED");
+			Thread.sleep(1000);
+			System.out.println("state: RUNNING");
+			sendRegistRequest(url);
+			Thread.sleep(5000);
+			System.out.println("[Error] Exception: xxxxxxxxxxxx");
+			System.exit(10);
+		} else if (isException) {
+			Thread.sleep(1000);
+			System.out.println("state: ACCEPTED");
+			Thread.sleep(1000);
+			System.out.println("state: RUNNING");
+			sendRegistRequest(url);
+			Thread.sleep(5000);
+			throw new Exception("Runnning After Exception");
+		} else {
+			try {
+				Thread.sleep(1000);
+				System.out.println("state: ACCEPTED");
+				Thread.sleep(1000);
+				System.out.println("state: RUNNING");
+				sendRegistRequest(url);
+				Thread.sleep(5000);
+				long startTime = System.currentTimeMillis();
+				while (System.currentTimeMillis() - startTime < 30000) {
+					Thread.sleep(1000);
+					System.out.println("state: RUNNNING");
+				}
+			} catch (Exception e) {
+				e.printStackTrace();
+				throw e;
+			}
+		}
+		System.exit(0);
+	}
+
+	private static void sendRegistRequest(String urlString) {
+		HttpURLConnection connection = null;
+		try {
+			URL url = new URL(urlString);
+			connection = (HttpURLConnection) url.openConnection();
+			connection.setDoOutput(true);
+			connection.setRequestMethod("POST");
+			BufferedWriter writer = new BufferedWriter(
+					new OutputStreamWriter(connection.getOutputStream(), StandardCharsets.UTF_8));
+			writer.write("{\"action\": \"register\", \"ip\": \"localhost\",\"port\": 12345}");
+			writer.flush();
+
+			if (connection.getResponseCode() == HttpURLConnection.HTTP_OK) {
+				try (InputStreamReader isr = new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8);
+						BufferedReader reader = new BufferedReader(isr)) {
+					String line;
+					while ((line = reader.readLine()) != null) {
+						System.out.println(line);
+					}
+				}
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		} finally {
+			if (connection != null) {
+				connection.disconnect();
+			}
+		}
+
+	}
+}

--- a/gateway/src/test/resources/dummy/spark-submit
+++ b/gateway/src/test/resources/dummy/spark-submit
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+java -cp target/scala-2.10/test-classes DummySparkSubmit $@
+
+exit $?

--- a/gateway/src/test/resources/spark.xml.dist
+++ b/gateway/src/test/resources/spark.xml.dist
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<properties>
+<!-- [spark xx path] should be replaced with actual spark path. -->
+<entry key="spark_home_path">[spark home path]</entry>
+<entry key="dummy_spark_home_path">src/test/resource/dummy</entry>
+</properties>

--- a/gateway/src/test/scala/us/jubat/jubaql_server/gateway/DummyStore.scala
+++ b/gateway/src/test/scala/us/jubat/jubaql_server/gateway/DummyStore.scala
@@ -1,0 +1,107 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2015 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+package us.jubat.jubaql_server.gateway
+
+import scala.collection.mutable._
+
+class DummyStore extends SessionStore {
+
+  override def getAllSessions(gatewayId: String): Map[String, SessionState] = {
+    println(s"call getAllSessions gatewayId= ${gatewayId}")
+    if (gatewayId.contains("getAllSessionsFailed")) {
+      throw new Exception("getAllSessionsFailed")
+    }
+    val result = Map.empty[String, SessionState]
+    result += "dummySession1" -> SessionState.Ready("dummyHost1",11111,"dummyKey1")
+    result += "dummySession2" -> SessionState.Ready("dummyHost2",11112,"dummyKey2")
+    result += "dummySession3" -> SessionState.Registering("dummyKey3")
+    result += "dummySession4" -> SessionState.Inconsistent
+    result += "dummySession5" -> SessionState.NotFound
+    result += "dummySession6" -> null
+  }
+
+  override def getSession(gatewayId: String, sessionId: String): SessionState = {
+    println(s"call getSession : gatewayId= ${gatewayId}, sessionId= ${sessionId}")
+    if (gatewayId.contains("getSessionFailed")) {
+      throw new Exception("getSessionFailed")
+    }
+    val notfoundRe = """(.*Notfound.*)""".r
+    val inconsistentRe = """(.*Inconsistent.*)""".r
+    val registeringRe = """(.*Registering.*)""".r
+    val readyRe = """(.*Ready.*)""".r
+
+    sessionId match {
+      case notfoundRe(id) => SessionState.NotFound
+      case inconsistentRe(id) => SessionState.Inconsistent
+      case registeringRe(id) => SessionState.Registering("registeringKey")
+      case readyRe(id) => SessionState.Ready("readyHost",12345,"readyKey")
+    }
+  }
+  override def preregisterSession(gatewayId: String, sessionId: String, key: String): Unit = {
+    println(s"call preregisterSession: gatewayId= ${gatewayId}, sessionId= ${sessionId}, key= ${key}")
+    if (gatewayId.contains("preregisterSessionFailed")) {
+      throw new Exception("preregisterSessionFailed")
+    }
+  }
+  override def registerSession(gatewayId: String, sessionId: String, host: String, port: Int, key: String): Unit = {
+    println(s"call registerSession: gatewayId= ${gatewayId}, sessionId= ${sessionId}, host= ${host}, port= ${port}, key= ${key}")
+    if (gatewayId.contains("registerSessionFailed")) {
+      throw new Exception("registerSessionFailed")
+    }
+  }
+  override def deleteSession(gatewayId: String, sessionId: String): Unit = {
+    println(s"call deleteSession: gatewayId= ${gatewayId}, sessionId= ${sessionId}")
+    if (gatewayId.contains("deleteSessionFailed")) {
+      throw new Exception("deleteSessionFailed")
+    } else if (gatewayId.contains("deleteSessionByIdFailed")) {
+      throw new Exception("deleteSessionByIdFailed")
+    }
+  }
+  override def lock(gatewayId: String): SessionLock = {
+    println(s"call lock: gatewayId= ${gatewayId}")
+    if (gatewayId.contains("lockFailed")) {
+      throw new Exception("lockFailed")
+    }
+    new SessionLock(gatewayId)
+  }
+  override def unlock(lock: SessionLock): Unit = {
+    if (lock != null ){
+      println(s"call unlock: lockObject: ${lock.lockObject}")
+    } else {
+      println("call unlock: lockObject: null")
+    }
+    if (lock != null && lock.lockObject != null && lock.lockObject.toString.contains("unLockFailed")) {
+      throw new Exception("unLockFailed")
+    }
+  }
+  override def addDeleteListener(gatewayId: String, sessionId: String, deleteFunction: Function1[String, Unit] = null): Unit = {
+    println(s"call addDeleteListener: gatewayId= ${gatewayId}, sessionId= ${sessionId}")
+    if (gatewayId.contains("addDeleteListenerFailed")) {
+      throw new Exception("addDeleteListenerFailed")
+    }
+  }
+
+  override def registerGateway(gatewayId: String): Unit = {
+    println(s"call registerGateway: gatewayId= ${gatewayId}")
+    if (gatewayId.contains("registerGatewayFailed")) {
+      throw new Exception("registerGatewayFailed")
+    }
+  }
+
+  override def close(): Unit = {
+    println(s"call close")
+  }
+}

--- a/gateway/src/test/scala/us/jubat/jubaql_server/gateway/GatewayPlanSpec.scala
+++ b/gateway/src/test/scala/us/jubat/jubaql_server/gateway/GatewayPlanSpec.scala
@@ -1,0 +1,65 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2015 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+package us.jubat.jubaql_server.gateway
+
+import org.scalatest._
+import dispatch._
+import dispatch.Defaults._
+import scala.util.Success
+import unfiltered.netty.Server
+
+class GatewayPlanSpec extends FlatSpec with Matchers with HasSpark {
+
+  "startingTimeout propery non exist" should "reflect default value" in {
+    // System.setProperty("", arg1)
+    val plan = new GatewayPlan("example.com", 1234,
+      Array(), RunMode.Test,
+      sparkDistribution = "",
+      fatjar = "src/test/resources/processor-logfile.jar",
+      checkpointDir = "file:///tmp/spark", "localhost:9877", false)
+    plan.submitTimeout shouldBe (60000)
+  }
+
+  "startingTimeout propery exist" should "reflect value" in {
+    System.setProperty("jubaql.gateway.submitTimeout", "12345")
+    val plan = new GatewayPlan("example.com", 1234,
+      Array(), RunMode.Test,
+      sparkDistribution = "",
+      fatjar = "src/test/resources/processor-logfile.jar",
+      checkpointDir = "file:///tmp/spark", "localhost:9877", false)
+    plan.submitTimeout shouldBe (12345)
+  }
+
+  "startingTimeout propery illegal value" should "reflect default value" in {
+    System.setProperty("jubaql.gateway.submitTimeout", "fail")
+    val plan = new GatewayPlan("example.com", 1234,
+      Array(), RunMode.Test,
+      sparkDistribution = "",
+      fatjar = "src/test/resources/processor-logfile.jar",
+      checkpointDir = "file:///tmp/spark", "localhost:9877", false)
+    plan.submitTimeout shouldBe (60000)
+  }
+
+  "startingTimeout propery negative value" should "reflect default value" in {
+    System.setProperty("jubaql.gateway.submitTimeout", "-30000")
+    val plan = new GatewayPlan("example.com", 1234,
+      Array(), RunMode.Test,
+      sparkDistribution = "",
+      fatjar = "src/test/resources/processor-logfile.jar",
+      checkpointDir = "file:///tmp/spark", "localhost:9877", false)
+    plan.submitTimeout shouldBe (60000)
+  }
+}

--- a/gateway/src/test/scala/us/jubat/jubaql_server/gateway/GatewayServer.scala
+++ b/gateway/src/test/scala/us/jubat/jubaql_server/gateway/GatewayServer.scala
@@ -16,22 +16,64 @@
 package us.jubat.jubaql_server.gateway
 
 import org.scalatest.{Suite, BeforeAndAfterAll}
+import scala.sys.process.ProcessLogger
+import org.apache.curator.test.TestingServer
+import unfiltered.netty.Server
 
-trait GatewayServer extends BeforeAndAfterAll {
+trait GatewayServer extends BeforeAndAfterAll with HasSpark {
   this: Suite =>
+
+  val zkServer = new TestingServer(2181,true)
 
   protected val plan = new GatewayPlan("example.com", 1234,
                                        Array(), RunMode.Test,
                                        sparkDistribution = "",
                                        fatjar = "src/test/resources/processor-logfile.jar",
-                                       checkpointDir = "file:///tmp/spark")
+                                       checkpointDir = "file:///tmp/spark", "localhost:9877", false)
   protected val server = unfiltered.netty.Server.http(9877).plan(plan)
+
+  val replan = new GatewayPlan("example.com", 1234,
+                                       Array(), RunMode.Test,
+                                       sparkDistribution = "",
+                                       fatjar = "src/test/resources/processor-logfile.jar",
+                                       checkpointDir = "file:///tmp/spark", "localhost:9877", false)
+  protected val reserver = unfiltered.netty.Server.http(9877).plan(replan)
+
+  //run.mode=production指定サーバ
+  protected val pro_plan = new GatewayPlan("example.com", 1235,
+                                       Array(), RunMode.Production("localhost"),
+                                       sparkDistribution = sparkPath,
+                                       fatjar = "src/test/resources/processor-logfile.jar",
+                                       checkpointDir = "file:///tmp/spark", "localhost:9878", false)
+  protected val pro_server = unfiltered.netty.Server.http(9878).plan(pro_plan)
+
+  //run.mode=development指定サーバ
+  protected val dev_plan = new GatewayPlan("example.com", 1236,
+                                       Array(), RunMode.Development(1),
+                                       sparkDistribution = sparkPath,
+                                       fatjar = "src/test/resources/processor-logfile.jar",
+                                       checkpointDir = "file:///tmp/spark", "localhost:9879", false)
+  protected val dev_server = unfiltered.netty.Server.http(9879).plan(dev_plan)
+
+  protected val persist_plan = new GatewayPlan("example.com", 1237,
+                                       Array(), RunMode.Test,
+                                       sparkDistribution = "",
+                                       fatjar = "src/test/resources/processor-logfile.jar",
+                                       checkpointDir = "file:///tmp/spark", "localhost:9880", true)
+  protected val persist_server = unfiltered.netty.Server.http(9880).plan(persist_plan)
 
   override protected def beforeAll() = {
     server.start()
+    pro_server.start()
+    dev_server.start()
+    persist_server.start()
   }
 
   override protected def afterAll() = {
     server.stop()
+    pro_server.stop()
+    dev_server.stop()
+    persist_server.stop()
+    zkServer.stop()
   }
 }

--- a/gateway/src/test/scala/us/jubat/jubaql_server/gateway/HasSpark.scala
+++ b/gateway/src/test/scala/us/jubat/jubaql_server/gateway/HasSpark.scala
@@ -1,0 +1,49 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2014-2015 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+package us.jubat.jubaql_server.gateway
+
+import java.io.{FileInputStream, FileNotFoundException}
+import java.util.Properties
+
+import org.scalatest._
+
+trait HasSpark extends ShouldMatchers {
+  lazy val sparkPath: String = {
+    val properties = loadProperties()
+    properties.getProperty("spark_home_path")
+  }
+
+  lazy val dummySparkPath: String = {
+    val properties = loadProperties()
+    properties.getProperty("dummy_spark_home_path")
+  }
+
+  private def loadProperties(): Properties = {
+        val sparkConfig = "src/test/resources/spark.xml"
+
+    val is = try {
+      Some(new FileInputStream(sparkConfig))
+    } catch {
+      case _: FileNotFoundException =>
+        None
+    }
+    is shouldBe a[Some[_]]
+
+    val properties = new Properties()
+    properties.loadFromXML(is.get)
+    properties
+  }
+}

--- a/gateway/src/test/scala/us/jubat/jubaql_server/gateway/JubaQLGatewaySpec.scala
+++ b/gateway/src/test/scala/us/jubat/jubaql_server/gateway/JubaQLGatewaySpec.scala
@@ -1,0 +1,53 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2015 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+package us.jubat.jubaql_server.gateway
+
+import org.scalatest._
+
+class JubaQLGatewaySpec extends FlatSpec with Matchers {
+
+  "Parameter gatewyId" should "return gatewayid" in {
+    // 省略時。パラメータから取得するgatewayIDは空。後で[host_port]の形式で生成する。
+    var result = JubaQLGateway.parseCommandlineOption(Array("-i", "localhost"))
+    result.get should not be None
+    result.get.gatewayId shouldBe ("")
+    // 1文字オプションによるgatewayID指定
+    result = JubaQLGateway.parseCommandlineOption(Array("-i", "localhost", "-g", "gatewayid"))
+    result.get should not be None
+    result.get.gatewayId shouldBe ("gatewayid")
+    // ロングオプションによるgatewayID指定
+    result = JubaQLGateway.parseCommandlineOption(Array("-i", "localhost", "--gatewayID", "gatewayid2"))
+    result.get should not be None
+    result.get.gatewayId shouldBe ("gatewayid2")
+  }
+  "Parameter persist" should "return persist" in {
+    // 省略時
+    var result = JubaQLGateway.parseCommandlineOption(Array("-i", "localhost"))
+    result.get should not be None
+    result.get.persist shouldBe (false)
+    // オプション指定
+    result = JubaQLGateway.parseCommandlineOption(Array("-i", "localhost", "--persist"))
+    result.get should not be None
+    result.get.persist shouldBe (true)
+  }
+  "Illegal parameter" should "stderr usage" in {
+    // 不正オプション時のusgageチェック
+    val result = JubaQLGateway.parseCommandlineOption(Array("-i"))
+    result shouldBe (None)
+    // Usageは目視確認
+  }
+
+}

--- a/gateway/src/test/scala/us/jubat/jubaql_server/gateway/JubaQLSpec.scala
+++ b/gateway/src/test/scala/us/jubat/jubaql_server/gateway/JubaQLSpec.scala
@@ -15,23 +15,31 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 package us.jubat.jubaql_server.gateway
 
+import us.jubat.jubaql_server.gateway.json.SessionId
 import us.jubat.jubaql_server.gateway.json.Query
 import org.scalatest._
 import EitherValues._
 import dispatch._
 import dispatch.Defaults._
-import org.json4s.DefaultFormats
-import org.json4s.native.Serialization.write
+import org.json4s._
+import org.json4s.Formats._
+import org.json4s.native.Serialization.{read, write}
+import org.json4s.native.JsonMethods._
+import org.json4s.JsonDSL._
 
 // We use mock processor in this test, so queries are dummies.
 
 class JubaQLSpec extends FlatSpec with Matchers with ProcessorAndGatewayServer {
   val jubaQlUrl  = :/("localhost", 9877) / "jubaql"
 
+  val persist_jubaQlUrl  = :/("localhost", 9880) / "jubaql"
+  val register_persist_jubaQlUrl  = :/("localhost", 9880) / "registration"
+  val persist_loginUrl  = :/("localhost", 9880) / "login"
+
   implicit val formats = DefaultFormats
 
-  def requestAsJson() = {
-    val request = (jubaQlUrl).POST
+  def requestAsJson(url : Req = jubaQlUrl) = {
+    val request = (url).POST
     request.setContentType("application/json", "UTF-8")
   }
 
@@ -56,6 +64,17 @@ class JubaQLSpec extends FlatSpec with Matchers with ProcessorAndGatewayServer {
     result.right.value.getContentType should include("charset=utf-8")
   }
 
+  "Posting jubaql with inconsistent data" should "fail" in {
+    plan.sessionManager.session2key += ("sessionId" -> null)
+    plan.sessionManager.key2session += ("sessionKey" -> "persistSessionId")
+    plan.sessionManager.session2loc += ("sessionId" -> ("localhost", 9876))
+
+    val request = requestAsJson(jubaQlUrl) << write(Query("sessionId", "query")).toString
+    val result = Http(request > (x => x)).either.apply()
+    result.right.value.getStatusCode shouldBe 500
+    result.right.value.getContentType should include("charset=utf-8")
+  }
+
   "Posting jubaql without query" should "fail" in {
     val request = requestAsJson() << f"""{"session_id": "$session%s"}"""
     val result = Http(request > (x => x)).either.apply()
@@ -74,6 +93,107 @@ class JubaQLSpec extends FlatSpec with Matchers with ProcessorAndGatewayServer {
     val request = requestAsJson() << write(Query(session, "query")).toString
     val result = Http(request > (x => x)).either.apply()
     result.right.value.getStatusCode shouldBe 200
+    result.right.value.getContentType should include("charset=utf-8")
+  }
+
+  // persist
+  // sesssion Idなし
+  "Posting jubaql with unknown session id in persist" should "fail" in {
+    println(session)
+    val request = requestAsJson(persist_jubaQlUrl) << write(Query(session, "query")).toString
+    val result = Http(request > (x => x)).either.apply()
+    result.right.value.getStatusCode shouldBe 401
+    result.right.value.getContentType should include("charset=utf-8")
+  }
+
+  // register yet
+  "Posting jubaql with register yet in persist" should "fail" in {
+    val connectedSessionId = {
+      val req = Http(persist_loginUrl.POST OK as.String)
+      req.option.apply.get
+    }
+    println("first connect : " + connectedSessionId)
+    // Register
+    val json = parseOpt(connectedSessionId)
+    val sessionId = json.get.extractOpt[SessionId].get.session_id
+
+    val request = requestAsJson(persist_jubaQlUrl) << write(Query(sessionId, "query")).toString
+    val result = Http(request > (x => x)).either.apply()
+    result.right.value.getStatusCode shouldBe 503
+    result.right.value.getContentType should include("charset=utf-8")
+  }
+
+  // キャッシュからセッション取得
+  "Posting jubaql with exist session cache in persist" should "succeed" in {
+    persist_plan.sessionManager.session2key += ("persistSessionId" -> "persistSessionKey")
+    persist_plan.sessionManager.session2loc += ("persistSessionId" -> ("localhost", 9876))
+    val request = requestAsJson(persist_jubaQlUrl) << write(Query("persistSessionId", "query")).toString
+    val result = Http(request > (x => x)).either.apply()
+    result.right.value.getStatusCode shouldBe 200
+    result.right.value.getContentType should include("charset=utf-8")
+  }
+
+  // Zookeeperにセッションあり(キャッシュはなし)
+  "Posting jubaql with exist session zookeeper in persist" should "succeed" in {
+    val connectedSessionId = {
+      val req = Http(persist_loginUrl.POST OK as.String)
+      req.option.apply.get
+    }
+    println("first connect : " + connectedSessionId)
+    //Register
+    val json = parseOpt(connectedSessionId)
+    val sessionId = json.get.extractOpt[SessionId].get.session_id
+    val key = persist_plan.sessionManager.session2key.get(sessionId).get
+    val registJsonString = """{ "action": "register", "ip": "localhost", "port": 9876 }"""
+    Http(register_persist_jubaQlUrl./(key).POST << registJsonString).either.apply() match {
+      case Right(resultJson) =>
+        println("register success: " + resultJson.getResponseBody)
+      case Left(t) =>
+        t.printStackTrace()
+        fail(t)
+    }
+    // キャッシュを削除
+    persist_plan.sessionManager.session2key -= sessionId
+    persist_plan.sessionManager.key2session -= key
+    persist_plan.sessionManager.session2loc -= sessionId
+
+    val request = requestAsJson(persist_jubaQlUrl) << write(Query(sessionId, "query")).toString
+    val result = Http(request > (x => x)).either.apply()
+    result.right.value.getStatusCode shouldBe 200
+    result.right.value.getContentType should include("charset=utf-8")
+  }
+
+  // Zookeeperへの接続失敗
+  "Posting jubaql with failed connect zookeeper in persist" should "fail" in {
+    val connectedSessionId = {
+      val req = Http(persist_loginUrl.POST OK as.String)
+      req.option.apply.get
+    }
+    println("first connect : " + connectedSessionId)
+    // Register
+    val json = parseOpt(connectedSessionId)
+    val sessionId = json.get.extractOpt[SessionId].get.session_id
+    val key = persist_plan.sessionManager.session2key.get(sessionId).get
+    val registJsonString = """{ "action": "register", "ip": "localhost", "port": 9876 }"""
+    Http(register_persist_jubaQlUrl./(key).POST << registJsonString).either.apply() match {
+      case Right(resultJson) =>
+        println("register success: " + resultJson.getResponseBody)
+      case Left(t) =>
+        t.printStackTrace()
+        fail(t)
+    }
+    // 試験用にキャッシュ情報を削除
+    persist_plan.sessionManager.session2key -= sessionId
+    persist_plan.sessionManager.key2session -= key
+    persist_plan.sessionManager.session2loc -= sessionId
+
+    // Zookeeper停止
+    zkServer.stop()
+
+    val request = requestAsJson(persist_jubaQlUrl) << write(Query(sessionId, "query")).toString
+    val result = Http(request > (x => x)).either.apply()
+    println(result.right.value.getResponseBody)
+    result.right.value.getStatusCode shouldBe 500
     result.right.value.getContentType should include("charset=utf-8")
   }
 }

--- a/gateway/src/test/scala/us/jubat/jubaql_server/gateway/LoginSpec.scala
+++ b/gateway/src/test/scala/us/jubat/jubaql_server/gateway/LoginSpec.scala
@@ -23,12 +23,28 @@ import org.json4s._
 import org.json4s.Formats._
 import org.json4s.native.Serialization.{read, write}
 import org.json4s.native.JsonMethods._
+import org.json4s.JsonDSL._
+import scala.concurrent.duration.Duration
+import scala.concurrent.Await
+import scala.async.Async.{async, await}
+import scala.concurrent.ExecutionContext
+import unfiltered.netty.Server
+import scala.util.Success
 
-class LoginSpec extends FlatSpec with Matchers with GatewayServer {
+class LoginSpec extends FlatSpec with Matchers with GatewayServer with BeforeAndAfter {
 
   implicit val formats = DefaultFormats
 
+  before {
+    zkServer.restart
+  }
+
   val url = :/("localhost", 9877) / "login"
+  val regist_url = :/("localhost", 9877) / "registration"
+  val pro_url = :/("localhost", 9878) / "login"
+  val dev_url = :/("localhost", 9879) / "login"
+  val persist_url = :/("localhost", 9880) / "login"
+  val persist_regist_url = :/("localhost", 9880) / "registration"
 
   "POST to /login" should "return something" in {
     val req = Http(url.POST OK as.String)
@@ -52,5 +68,489 @@ class LoginSpec extends FlatSpec with Matchers with GatewayServer {
     val maybeSessionId = maybeJson.get.extractOpt[SessionId]
     maybeSessionId should not be None
     maybeSessionId.get.session_id.length should be > 0
+
+  }
+
+  "POST to /login reconnect" should "not exist sessionId. return Error Response(unknown sessioId)" in {
+    //
+    val sessionId = "testSessionId"
+    val payloadData = ("session_id" -> sessionId)
+    val json: String = compact(render(payloadData))
+
+    val req = Http(url.POST << json)// OK as.String)
+    req.either.apply() match {
+      case Right(response) =>
+        response.getStatusCode shouldEqual(401)
+        response.getResponseBody shouldBe("Unknown session_id")
+      case Left(t) =>
+        t.printStackTrace()
+        fail(t)
+    }
+  }
+
+  "POST to /login reconnect" should "session inconsistency. return Error Response(inconsist data)" in {
+    // 初回接続
+    val connectedSessionId = connection(url)
+
+    println("first connect : " + connectedSessionId)
+    //session情報を不整合状態に書き換え
+    plan.sessionManager.session2key -= connectedSessionId
+    plan.sessionManager.session2key += connectedSessionId -> null
+    plan.sessionManager.session2loc += connectedSessionId -> ("dummyHost", 9999)
+
+    //接続済sessionIdを利用した接続
+    val payloadData = ("session_id" -> connectedSessionId)
+    val json: String = compact(render(payloadData))
+
+    val req = Http(url.POST << json)
+    req.either.apply() match {
+      case Right(response) =>
+        println(response.getResponseBody)
+        response.getStatusCode shouldEqual(500)
+        response.getResponseBody shouldBe("Failed to get session")
+      case Left(t) =>
+        t.printStackTrace()
+        fail(t)
+    }
+  }
+
+  "POST to /login reconnect" should "exist sessionId, but registered yet. return Error Response(registered yet)" in {
+    // 初回接続
+    val connectedSessionId = connection(url)
+
+    println("first connect : " + connectedSessionId)
+    //接続済sessionIdを利用した接続
+    val payloadData = ("session_id" -> connectedSessionId)
+    val json: String = compact(render(payloadData))
+
+    val req = Http(url.POST << json)
+    req.either.apply() match {
+      case Right(response) =>
+        response.getStatusCode shouldEqual(503)
+        response.getResponseBody shouldBe("This session has not been registered. Wait a second.")
+      case Left(t) =>
+        t.printStackTrace()
+        fail(t)
+    }
+  }
+
+  // RunMode.testで実施(非永続化)
+  "POST to /login reconnect" should "success reconnect" in {
+    // 初回接続
+    val connectedSessionId = connection(url)
+
+    println("first connect : " + connectedSessionId)
+
+    //疑似Registration
+    registration(regist_url,plan,connectedSessionId)
+
+    //接続済sessionIdを利用した接続
+    reconnection(url,connectedSessionId)
+  }
+
+  // 非永続化における再接続(接続失敗ケース)
+  "POST to /login reconnect" should "reboot gateaway" in {
+    // 初回接続
+    val connectedSessionId = connection(url)
+
+    println("first connect : " + connectedSessionId)
+
+    //疑似Registration
+    registration(regist_url,plan,connectedSessionId)
+
+    // Gateway再起動
+    server.stop()
+    reserver.start()
+
+    // 接続済sessionIdを利用した接続
+    val payloadData = ("session_id" -> connectedSessionId)
+    val json: String = compact(render(payloadData))
+
+    val req = Http(url.POST << json)
+
+    // 永続化していないため、エラーレスポンス返却
+    req.option.apply.get.getStatusCode shouldBe(401)
+    req.option.apply.get.getResponseBody shouldBe("Unknown session_id")
+    reserver.stop()
+  }
+
+  // 永続化確認
+  "reconnect in persist" should "save session to zookeeper" in {
+    // 初回接続
+    val connectedSessionId = connection(persist_url)
+
+    println("first connect : " + connectedSessionId)
+
+    //疑似Registration
+    registration(persist_regist_url, persist_plan, connectedSessionId)
+
+    //接続済sessionIdを利用した接続
+    reconnection(persist_url, connectedSessionId)
+
+    // キャッシュへのセッション情報格納を確認
+    val cacheKey = persist_plan.sessionManager.session2key.get(connectedSessionId)
+    val cacheSessionId = persist_plan.sessionManager.key2session.get(cacheKey.get)
+    val cacheLocation = persist_plan.sessionManager.session2loc.get(connectedSessionId)
+    cacheKey.get.length() should be > 0
+    cacheSessionId.get shouldBe (connectedSessionId)
+    cacheLocation.get shouldBe (("dummyhost", 1111))
+
+    // zkへのセッション情報格納を確認
+    val storeSession: SessionState = persist_plan.sessionManager.getSessionFromStore(connectedSessionId)
+    storeSession shouldBe SessionState.Ready("dummyhost", 1111, cacheKey.get)
+    val completeSession = storeSession.asInstanceOf[SessionState.Ready]
+    completeSession.host shouldBe "dummyhost"
+    completeSession.port shouldBe 1111
+    completeSession.key shouldBe cacheKey.get
+  }
+
+   // Gatewayサーバ再起動によるセッション接続
+  "reconnect in persist" should "reboot gateway" in {
+    // 初回接続
+    val firstplan = new GatewayPlan("example.com", 1880,
+      Array(), RunMode.Test,
+      sparkDistribution = "",
+      fatjar = "src/test/resources/processor-logfile.jar",
+      checkpointDir = "file:///tmp/spark", "localhost:8880", true)
+    val firstserver = unfiltered.netty.Server.http(8880).plan(firstplan)
+    firstserver.start()
+
+    val url1 = :/("localhost", 8880) / "login"
+    val regist_url1 = :/("localhost", 8880) / "registration"
+    val connectedSessionId = connection(url1)
+
+    println("first connect : " + connectedSessionId)
+
+    // 疑似Registration
+    registration(regist_url1, firstplan, connectedSessionId)
+
+    // Gateway停止
+    firstserver.stop()
+
+    // Gateway再起動
+    val secondplan = new GatewayPlan("example.com", 1880,
+      Array(), RunMode.Test,
+      sparkDistribution = "",
+      fatjar = "src/test/resources/processor-logfile.jar",
+      checkpointDir = "file:///tmp/spark", "localhost:8880", true)
+    val secondserver = unfiltered.netty.Server.http(8880).plan(secondplan)
+    secondserver.start()
+
+    // 接続済sessionIdを利用した接続
+    reconnection(url1, connectedSessionId)
+
+    // キャッシュへのセッション情報格納を確認
+    val cacheKey = secondplan.sessionManager.session2key.get(connectedSessionId)
+    val cacheSessionId = secondplan.sessionManager.key2session.get(cacheKey.get)
+    val cacheLocation = secondplan.sessionManager.session2loc.get(connectedSessionId)
+    cacheKey.get.length() should be > 0
+    cacheSessionId.get shouldBe (connectedSessionId)
+    cacheLocation.get shouldBe (("dummyhost", 1111))
+
+    // zookeeperへのセッション情報格納を確認
+    val storeSession: SessionState = secondplan.sessionManager.getSessionFromStore(connectedSessionId)
+    storeSession.isInstanceOf[SessionState.Ready].shouldBe(true)
+    val completeSession = storeSession.asInstanceOf[SessionState.Ready]
+    completeSession.host shouldBe "dummyhost"
+    completeSession.port shouldBe 1111
+    completeSession.key shouldBe cacheKey.get
+    secondserver.stop()
+    firstplan.close()
+    secondplan.close()
+  }
+
+  "zookeeper connection failed" should "throw Exception" in {
+    zkServer.stop()
+    try {
+      new GatewayPlan("example.com", 1237,
+        Array(), RunMode.Test,
+        sparkDistribution = "",
+        fatjar = "src/test/resources/processor-logfile.jar",
+        checkpointDir = "file:///tmp/spark", "localhost:9877", true)
+      fail()
+    } catch {
+      case e: Exception =>
+        e.getMessage().shouldBe("failed to connected zookeeper")
+    }
+  }
+
+  "POST to /login stop zookeeper" should "failed login" in {
+    zkServer.stop()
+    val req = Http(persist_url.POST)
+    req.option.apply.get.getStatusCode.shouldBe(500)
+    req.option.apply.get.getResponseBody.shouldBe("Failed to create session")
+  }
+
+  "POST to /login stop zookeeper(reconnect)" should "failed login" in {
+    zkServer.stop()
+    val payloadData = ("session_id" -> "testSessionId")
+    val json: String = compact(render(payloadData))
+
+    val req = Http(persist_url.POST << json)
+    req.option.apply.get.getStatusCode.shouldBe(500)
+    req.option.apply.get.getResponseBody.shouldBe("Failed to get session")
+  }
+
+  "POST to /login clustering" should "succeed" in {
+    val url1 = :/("localhost", 9890) / "login"
+    val regist_url1 = :/("localhost", 9890) / "registration"
+    val url2 = :/("localhost", 9891) / "login"
+    val regist_url2 = :/("localhost", 9891) / "registration"
+    val clustername = "gwCluster"
+
+    val node1_plan = new GatewayPlan("example.com", 1290,
+      Array(), RunMode.Test,
+      sparkDistribution = "",
+      fatjar = "src/test/resources/processor-logfile.jar",
+      checkpointDir = "file:///tmp/spark", clustername, true)
+    val server1 = unfiltered.netty.Server.http(9890).plan(node1_plan)
+    val node2_plan = new GatewayPlan("example.com", 1291,
+      Array(), RunMode.Test,
+      sparkDistribution = "",
+      fatjar = "src/test/resources/processor-logfile.jar",
+      checkpointDir = "file:///tmp/spark", clustername, true)
+    val server2 = unfiltered.netty.Server.http(9891).plan(node1_plan)
+    server1.start()
+    server2.start()
+
+    val connectedSessionId = connection(url1)
+    registration(regist_url1, node1_plan, connectedSessionId)
+    reconnection(url2, connectedSessionId)
+    val registeringId = connection(url2)
+    reconnectionNJ(url1, registeringId) shouldBe "This session has not been registered. Wait a second."
+  }
+
+  "spark-submit command succeed in developmentMode" should "succeed" in {
+    val url = :/("localhost", 1877) / "login"
+    val (server, plan) = startServer(RunMode.Development(), dummySparkPath)
+    val req = Http(url.POST OK as.String)
+    req.option.apply() should not be None
+    server.stop()
+  }
+
+  "spark-submit command failed(fail dummySparkPath) in developmentMode" should "fail" in {
+    val url = :/("localhost", 1877) / "login"
+    val (server, plan) = startServer(RunMode.Development(), "failpath")
+    val req = Http(url.POST)
+    req.either.apply() match {
+      case Right(res) =>
+        server.stop()
+        res.getStatusCode shouldBe(500)
+        res.getResponseBody should startWith("Failed to start Spark")
+      case Left(t) =>
+        t.printStackTrace()
+        server.stop()
+        fail()
+    }
+  }
+
+  "spark-submit command succeed in productionMode" should "succeed" in {
+    val url = :/("localhost", 1877) / "login"
+    val (server, plan) = startServer(RunMode.Production("localhost:2181"), dummySparkPath)
+    val req = Http(url.POST)
+    req.either.apply() match {
+      case Right(res) =>
+        server.stop()
+        res.getStatusCode shouldBe(200)
+        res.getResponseBody should not be None
+      case Left(t) =>
+        t.printStackTrace()
+        server.stop()
+        fail()
+    }
+
+  }
+
+  "spark-submit command failed(fail sparkpath) in productionMode" should "fail" in {
+    val url = :/("localhost", 1877) / "login"
+    val (server, plan) = startServer(RunMode.Production("localhost:2181"), "failpath")
+    val req = Http(url.POST)
+    req.either.apply() match {
+      case Right(res) =>
+        server.stop()
+        res.getStatusCode shouldBe(500)
+        res.getResponseBody should startWith("Failed to start Spark")
+      case Left(t) =>
+        t.printStackTrace()
+        fail()
+    }
+  }
+
+  "spark-submit command failed(timeout) in productionMode" should "fail" in {
+    val url = :/("localhost", 1877) / "login"
+    System.setProperty("jubaql.gateway.submitTimeout", "10000")
+    val (server, plan) = startServer(RunMode.Production("localhost:2181"), dummySparkPath, "file:///timeout")
+    val req = Http(url.POST)
+    req.either.apply() match {
+      case Right(res) =>
+        server.stop()
+        res.getStatusCode shouldBe(500)
+        res.getResponseBody should startWith("Failed to start Spark")
+      case Left(t) =>
+        t.printStackTrace()
+        server.stop()
+        fail()
+    }
+  }
+
+  "spark-submit command failed(return code: xx) in productionMode" should "fail" in {
+    val url = :/("localhost", 1877) / "login"
+    val (server, plan) = startServer(RunMode.Production("localhost:2181"), dummySparkPath, "file:///return")
+    val req = Http(url.POST)
+    req.either.apply() match {
+      case Right(res) =>
+        server.stop()
+        res.getStatusCode shouldBe(500)
+        res.getResponseBody should startWith("Failed to start Spark")
+      case Left(t) =>
+        t.printStackTrace()
+        server.stop()
+        fail()
+    }
+  }
+
+  "spark-submit command failed(after runnnig returun code:0) in productionMode" should "succeed" in {
+    val url = :/("localhost", 1877) / "login"
+    val (server, plan) = startServer(RunMode.Production("localhost:2181"), dummySparkPath, "file:///after")
+    val req = Http(url.POST)
+    val sessionId = req.either.apply() match {
+      case Right(res) =>
+        res.getStatusCode shouldBe(200)
+        val json = parseOpt(res.getResponseBody)
+        json.get.extractOpt[SessionId].get.session_id
+      case Left(t) =>
+        t.printStackTrace()
+        server.stop()
+        fail()
+    }
+    Thread.sleep(10000)
+    val state = plan.sessionManager.getSession(sessionId)
+    state.isSuccess shouldBe true
+    state.get shouldBe(SessionState.NotFound)
+    server.stop()
+  }
+
+  "spark-submit command failed(after runnnig returun code:10) in productionMode" should "succeed" in {
+    val url = :/("localhost", 1877) / "login"
+    val (server, plan) = startServer(RunMode.Production("localhost:2181"), dummySparkPath, "file:///afterFailed")
+    val req = Http(url.POST)
+    val sessionId = req.either.apply() match {
+      case Right(res) =>
+        res.getStatusCode shouldBe(200)
+        val json = parseOpt(res.getResponseBody)
+        json.get.extractOpt[SessionId].get.session_id
+      case Left(t) =>
+        t.printStackTrace()
+        server.stop()
+        fail()
+    }
+    Thread.sleep(10000)
+    val state = plan.sessionManager.getSession(sessionId)
+    state.isSuccess shouldBe true
+    state.get shouldBe(SessionState.NotFound)
+    server.stop()
+  }
+
+  "spark-submit command failed(after runnnig throw Exception) in productionMode" should "succeed" in {
+    val url = :/("localhost", 1877) / "login"
+    val (server, plan) = startServer(RunMode.Production("localhost:2181"), dummySparkPath, "file:///exception")
+    val req = Http(url.POST)
+    val sessionId = req.either.apply() match {
+      case Right(res) =>
+        res.getStatusCode shouldBe(200)
+        val json = parseOpt(res.getResponseBody)
+        json.get.extractOpt[SessionId].get.session_id
+      case Left(t) =>
+        t.printStackTrace()
+        server.stop()
+        fail()
+    }
+    Thread.sleep(10000)
+    val state = plan.sessionManager.getSession(sessionId)
+    state.isSuccess shouldBe true
+    state.get shouldBe(SessionState.NotFound)
+    server.stop()
+  }
+
+// ---------------------
+  private def connection(url: Req): String = {
+    val req = Http(url.POST OK as.String)
+    req.option.apply() should not be None
+    val returnedString = req.option.apply.get
+    val maybeJson = parseOpt(returnedString)
+    maybeJson should not be None
+    val maybeSessionId = maybeJson.get.extractOpt[SessionId]
+    maybeSessionId should not be None
+    //セッションIDの返却チェック
+    maybeSessionId.get.session_id.length should be > 0
+    maybeSessionId.get.session_id
+  }
+
+  private def connectionNJ(url: Req): String = {
+    val req = Http(url.POST OK as.String)
+    req.option.apply() should not be None
+    val returnedString = req.option.apply.get
+    val maybeJson = parseOpt(returnedString)
+    if (maybeJson == None) {
+      ""
+    } else {
+      val maybeSessionId = maybeJson.get.extractOpt[SessionId]
+      if (maybeSessionId == None) {
+        ""
+      } else {
+        maybeSessionId.get.session_id
+      }
+    }
+  }
+
+  private def reconnectionNJ(url: Req, sessionId: String):String = {
+    val payloadData = ("session_id" -> sessionId)
+    val json: String = compact(render(payloadData))
+    val req = Http(url.POST << json)
+    req.option.apply match {
+      case Some(res) =>
+        println(res.getResponseBody)
+        res.getResponseBody
+      case None =>
+        ""
+    }
+  }
+
+  private def reconnection(url:Req, sessionId: String) = {
+    val payloadData = ("session_id" -> sessionId)
+    val json: String = compact(render(payloadData))
+
+    val req = Http(url.POST << json)
+
+    val returnedString = req.option.apply.get.getResponseBody
+    val maybeJson = parseOpt(returnedString)
+    maybeJson should not be None
+    val maybeSessionId = maybeJson.get.extractOpt[SessionId]
+    maybeSessionId should not be None
+    // セッションIDの返却チェック
+    maybeSessionId.get.session_id shouldBe (sessionId)
+  }
+
+  private def registration(url: Req, plan: GatewayPlan, sessionId: String): Unit = {
+    val key = plan.sessionManager.session2key(sessionId)
+    val registJsonString = """{ "action": "register", "ip": "dummyhost", "port": 1111 }"""
+    Http(url./(key).POST << registJsonString).either.apply() match {
+      case Right(resultJson) =>
+        println(resultJson.getResponseBody)
+      case Left(t) =>
+        t.printStackTrace()
+        fail(t)
+    }
+  }
+
+  private def startServer(runMode:RunMode, sparkPath:String, checkpointDir: String = "file:///tmp/spark"): (Server, GatewayPlan) = {
+    val plan = new GatewayPlan("localhost", 1877,
+      Array(), runMode,
+      sparkDistribution = sparkPath,
+      fatjar = "src/test/resources/processor-logfile.jar",
+      checkpointDir, "localhost:1877", false)
+    val server = unfiltered.netty.Server.http(1877).plan(plan)
+    server.start()
+    (server, plan)
   }
 }

--- a/gateway/src/test/scala/us/jubat/jubaql_server/gateway/ProcessorAndGatewayServer.scala
+++ b/gateway/src/test/scala/us/jubat/jubaql_server/gateway/ProcessorAndGatewayServer.scala
@@ -39,9 +39,9 @@ trait ProcessorAndGatewayServer extends GatewayServer {
     )
 
   override def beforeAll(): Unit = {
-    plan.session2key += (session -> key_)
-    plan.key2session += (key_ -> session)
-    plan.session2loc += (session -> loc)
+    plan.sessionManager.session2key += (session -> key_)
+    plan.sessionManager.key2session += (key_ -> session)
+    plan.sessionManager.session2loc += (session -> loc)
     super.beforeAll()
 
     processorMock.start()

--- a/gateway/src/test/scala/us/jubat/jubaql_server/gateway/RegisterSpec.scala
+++ b/gateway/src/test/scala/us/jubat/jubaql_server/gateway/RegisterSpec.scala
@@ -24,17 +24,24 @@ import org.json4s.Formats._
 import org.json4s.native.Serialization.{read, write}
 import org.json4s.native.JsonMethods._
 import EitherValues._
+import us.jubat.jubaql_server.gateway.json.SessionId
 
-class RegisterSpec extends FlatSpec with Matchers with GatewayServer {
+class RegisterSpec extends FlatSpec with Matchers with GatewayServer with BeforeAndAfter {
 
   implicit val formats = DefaultFormats
 
   val loginUrl  = :/("localhost", 9877) / "login"
   val registrationUrl = :/("localhost", 9877) / "registration"
+  val persist_loginUrl  = :/("localhost", 9880) / "login"
+  val persist_registrationUrl = :/("localhost", 9880) / "registration"
 
-  def requestAsJson(key: String) = {
-    val request = (registrationUrl / key).POST
+  def requestAsJson(key: String, url: Req = registrationUrl) = {
+    val request = (url / key).POST
     request.setContentType("application/json", "UTF-8")
+  }
+
+  before {
+    zkServer.restart
   }
 
   override def beforeAll(): Unit = {
@@ -49,8 +56,8 @@ class RegisterSpec extends FlatSpec with Matchers with GatewayServer {
   def keys = {
     var keys = List.empty[String]
     // This lock is required because the server is in the same process.
-    plan.session2key.synchronized {
-      for (key <- plan.key2session.keys)
+    plan.sessionManager.session2key.synchronized {
+      for (key <- plan.sessionManager.key2session.keys)
         keys = key :: keys
     }
     keys
@@ -78,7 +85,7 @@ class RegisterSpec extends FlatSpec with Matchers with GatewayServer {
       val registerJson = write(Register("register", "8.8.8.8", 30))
       val requestWithBody = requestAsJson(garbageKey) << registerJson.toString
       val result = Http(requestWithBody OK as.String).either.apply()
-      result.left.value.getMessage shouldBe "Unexpected response status: 401"
+      result.left.value.getMessage shouldBe "Unexpected response status: 500"
     }
   }
 
@@ -87,10 +94,10 @@ class RegisterSpec extends FlatSpec with Matchers with GatewayServer {
       val registerJson = write(Register("register", "8.8.8.8", 30))
       val requestWithBody = requestAsJson(key) << registerJson.toString
       Http(requestWithBody OK as.String).option.apply() should not be None
-      plan.session2key.synchronized {
-        val session = plan.key2session.get(key)
+      plan.sessionManager.session2key.synchronized {
+        val session = plan.sessionManager.key2session.get(key)
         session should not be None
-        val maybeLoc = plan.session2loc.get(session.get)
+        val maybeLoc = plan.sessionManager.session2loc.get(session.get)
         maybeLoc should not be None
         val loc = maybeLoc.get
         loc shouldBe ("8.8.8.8", 30)
@@ -106,15 +113,105 @@ class RegisterSpec extends FlatSpec with Matchers with GatewayServer {
         val registerJson = write(Register("register", ip, port))
         val requestWithBody = requestAsJson(key) << registerJson.toString
         Http(requestWithBody OK as.String).option.apply() should not be None
-        plan.session2key.synchronized {
-          val session = plan.key2session.get(key)
+        plan.sessionManager.session2key.synchronized {
+          val session = plan.sessionManager.key2session.get(key)
           session should not be None
-          val maybeLoc = plan.session2loc.get(session.get)
+          val maybeLoc = plan.sessionManager.session2loc.get(session.get)
           maybeLoc should not be None
           val loc = maybeLoc.get
           loc shouldBe (ip, port)
         }
       }
+    }
+  }
+
+// persist
+  "Registering an existing key in persist" should "succeed" in {
+    List(0,1).par.foreach(key => {
+      val req = Http(persist_loginUrl.POST OK as.String)
+      req.option.apply()
+    })
+
+    var keys = List.empty[String]
+    // This lock is required because the server is in the same process.
+    persist_plan.sessionManager.session2key.synchronized {
+      for (key <- persist_plan.sessionManager.key2session.keys)
+        keys = key :: keys
+    }
+    keys.par.foreach(key => {
+      val registerJson = write(Register("register", s"8.8.8.8", 30))
+      val requestWithBody = requestAsJson(key, persist_registrationUrl) << registerJson.toString
+      Http(requestWithBody OK as.String).option.apply() should not be None
+      persist_plan.sessionManager.session2key.synchronized {
+        val session = persist_plan.sessionManager.key2session.get(key)
+        session should not be None
+        val maybeLoc = persist_plan.sessionManager.session2loc.get(session.get)
+        maybeLoc should not be None
+        val loc = maybeLoc.get
+        loc shouldBe (s"8.8.8.8", 30)
+      }
+    })
+  }
+
+  "Registering an Unknown key in persist" should "fail" in {
+    val req = Http(persist_loginUrl.POST OK as.String)
+    var sessionId = req.option.apply() match {
+      case Some(res) =>
+        parseOpt(res).get.extractOpt[SessionId].get.session_id
+      case None => fail()
+    }
+
+    var keys = List.empty[String]
+    // This lock is required because the server is in the same process.
+    persist_plan.sessionManager.session2key.synchronized {
+      for (key <- persist_plan.sessionManager.key2session.keys)
+        keys = key :: keys
+    }
+    //キー削除
+    val key = persist_plan.sessionManager.session2key.get(sessionId).get
+    persist_plan.sessionManager.key2session -= key
+
+    val registerJson = write(Register("register", s"8.8.8.8", 30))
+    val requestWithBody = requestAsJson(key, persist_registrationUrl) << registerJson.toString
+    val res = Http(requestWithBody).option.apply()
+    res match {
+      case Some(res) =>
+        res.getStatusCode.shouldBe(500)
+        res.getResponseBody.shouldBe(s"Failed to register key : ${key}")
+      case None =>
+        fail()
+    }
+
+  }
+
+  "Registering connect zookeeper failed in persist" should "fail" in {
+    val req = Http(persist_loginUrl.POST OK as.String)
+    val sessionId = req.option.apply() match {
+      case Some(res) =>
+        parseOpt(res).get.extractOpt[SessionId].get.session_id
+      case None => fail()
+    }
+
+    var keys = List.empty[String]
+    // This lock is required because the server is in the same process.
+    persist_plan.sessionManager.session2key.synchronized {
+      for (key <- persist_plan.sessionManager.key2session.keys)
+        keys = key :: keys
+    }
+    val key = persist_plan.sessionManager.session2key.get(sessionId).get
+    zkServer.stop()
+
+    val registerJson = write(Register("register", s"8.8.8.8", 30))
+    val requestWithBody = requestAsJson(key, persist_registrationUrl) << registerJson.toString
+    val res = Http(requestWithBody).option.apply()
+    res match {
+      case Some(res) =>
+        println(res.getStatusCode)
+        println(res.getResponseBody)
+        res.getStatusCode.shouldBe(500)
+        res.getResponseBody.shouldBe(s"Failed to register key : ${key}")
+      case None =>
+        fail()
     }
   }
 }

--- a/gateway/src/test/scala/us/jubat/jubaql_server/gateway/SessionManagerSpec.scala
+++ b/gateway/src/test/scala/us/jubat/jubaql_server/gateway/SessionManagerSpec.scala
@@ -1,0 +1,375 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2015 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+package us.jubat.jubaql_server.gateway
+
+import org.scalatest._
+import scala.util._
+
+
+class SessionManagerSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
+  val sessionManager = new SessionManager("gatewayID", new DummyStore)
+
+  "initCache()" should "succeed" in {
+    // コンストラクタで起動済みのセッション情報を利用
+    sessionManager.session2key.get("dummySession1").get shouldBe("dummyKey1")
+    sessionManager.session2key.get("dummySession2").get shouldBe("dummyKey2")
+    sessionManager.key2session.get("dummyKey1").get shouldBe("dummySession1")
+    sessionManager.key2session.get("dummyKey2").get shouldBe("dummySession2")
+    sessionManager.session2loc.get("dummySession1").get shouldBe(("dummyHost1",11111))
+    sessionManager.session2loc.get("dummySession2").get shouldBe(("dummyHost2",11112))
+  }
+
+  it should "fail" in {
+    try {
+      new SessionManager("addDeleteListenerFailed", new DummyStore)
+      fail()
+    } catch {
+      case e:Exception => e.getMessage shouldBe("addDeleteListenerFailed")
+    }
+  }
+
+  "createNewSession()" should "succeed" in {
+    //parallel execute
+    var resultMap = Map.empty[String, String]
+    List(1,2,3,4,5).par.foreach { x =>
+      val result = sessionManager.createNewSession()
+      result match {
+        case Success((id, key)) =>
+          id.length should be > 0
+          key.length should be > 0
+          resultMap += id -> key
+        case Failure(t) =>
+          t.printStackTrace()
+          fail()
+      }
+    }
+    for ((key,value) <- resultMap) {
+      sessionManager.session2key.get(key).get shouldBe value
+      sessionManager.key2session.get(value).get shouldBe key
+    }
+  }
+  it should "fail" in {
+    val sessionManager = new SessionManager("preregisterSessionFailed", new DummyStore)
+    val result = sessionManager.createNewSession()
+    result match {
+      case Success((id, key)) =>
+        fail()
+      case Failure(t) =>
+        t.getMessage shouldBe("preregisterSessionFailed")
+        sessionManager.session2key.size shouldBe 2 //dummysession
+        sessionManager.key2session.size shouldBe 2 //dummysession
+        sessionManager.session2loc.size shouldBe 2 //dummysession
+    }
+  }
+
+  "getSession() find readyState in cache" should "succeed" in {
+    val readyResult = sessionManager.getSession("dummySession1")
+    readyResult match {
+      case Success(state) if state.isInstanceOf[SessionState.Ready] =>
+        state.asInstanceOf[SessionState.Ready].host shouldBe("dummyHost1")
+        state.asInstanceOf[SessionState.Ready].port shouldBe(11111)
+        state.asInstanceOf[SessionState.Ready].key shouldBe("dummyKey1")
+      case Success(state) =>
+        println(state)
+        fail()
+      case Failure(t) =>
+        t.printStackTrace()
+        fail()
+    }
+  }
+  "getSession() find registeringState in cache" should "succeed" in {
+    //register registeringState
+    val (id,key) = sessionManager.createNewSession() match {
+      case Success((id, key)) => (id, key)
+      case Failure(t) =>
+        t.printStackTrace()
+        fail()
+    }
+    println("--- get registeringState ---")
+    val registeringResult = sessionManager.getSession(id)
+    registeringResult match {
+      case Success(state) if state.isInstanceOf[SessionState.Registering] =>
+        state.asInstanceOf[SessionState.Registering].key shouldBe(key)
+      case Success(state) =>
+        println(state)
+        fail()
+      case Failure(t) =>
+        t.printStackTrace()
+        fail()
+    }
+  }
+  "getSession() find inconsistantData in cache" should "succeed" in {
+    //register registeringState
+    val (id,key) = sessionManager.createNewSession() match {
+      case Success((id, key)) => (id, key)
+      case Failure(t) =>
+        t.printStackTrace()
+        fail()
+    }
+    //不整合データ生成
+    sessionManager.session2key -= id
+    sessionManager.session2key += id -> null
+    sessionManager.session2loc += id -> ("inconsistHost", 9999)
+
+    println("--- get inconsitantData ---")
+    sessionManager.getSession(id) match {
+      case Success(state) =>
+        fail()
+      case Failure(t) =>
+        t.getMessage shouldBe(s"Inconsistent data. sessionId: ${id}")
+    }
+  }
+
+  "getSession() find readyState in store" should "succeed" in {
+    val readyResult = sessionManager.getSession("ReadySession")
+    readyResult match {
+      case Success(state) if state.isInstanceOf[SessionState.Ready] =>
+        state.asInstanceOf[SessionState.Ready].host shouldBe("readyHost")
+        state.asInstanceOf[SessionState.Ready].port shouldBe(12345)
+        state.asInstanceOf[SessionState.Ready].key shouldBe("readyKey")
+        sessionManager.session2key.get("ReadySession").get shouldBe("readyKey")
+        sessionManager.key2session.get("readyKey").get shouldBe("ReadySession")
+        sessionManager.session2loc.get("ReadySession").get shouldBe(("readyHost",12345))
+      case Success(state) =>
+        println(state)
+        fail()
+      case Failure(t) =>
+        t.printStackTrace()
+        fail()
+    }
+  }
+  "getSession() find registeringState in store" should "succeed" in {
+    val registeringResult = sessionManager.getSession("RegisteringSession")
+    registeringResult match {
+      case Success(state) if state.isInstanceOf[SessionState.Registering] =>
+        state.asInstanceOf[SessionState.Registering].key shouldBe("registeringKey")
+        sessionManager.session2key.get("RegisteringSession") shouldBe None
+      case Success(state) =>
+        println(state)
+        fail()
+      case Failure(t) =>
+        t.printStackTrace()
+        fail()
+    }
+  }
+  "getSession() find notfoundState in store" should "succeed" in {
+    val notfoundResult = sessionManager.getSession("NotfoundSession")
+    notfoundResult match {
+      case Success(state) =>
+        state shouldBe SessionState.NotFound
+        sessionManager.session2key.get("NotfoundSession") shouldBe None
+      case Failure(t) =>
+        t.printStackTrace()
+        fail()
+    }
+  }
+  "getSession() find inconsistantState in store" should "succeed" in {
+    val inconsistantResult = sessionManager.getSession("InconsistentSession")
+    inconsistantResult match {
+      case Success(state) =>
+        fail()
+      case Failure(t) =>
+        t.getMessage shouldBe("Inconsistent data. sessionId: InconsistentSession")
+        sessionManager.session2key.get("InconsistentSession") shouldBe None
+    }
+  }
+  "getSession() sessionStore throw Exception" should "fail" in {
+    val sessionManager = new SessionManager("getSessionFailed", new DummyStore)
+    val result = sessionManager.getSession("NonSession")
+    result match {
+      case Success(state) =>
+        fail()
+      case Failure(t) =>
+        t.getMessage shouldBe("getSessionFailed")
+        sessionManager.session2key.size shouldBe 2 //dummysession
+        sessionManager.key2session.size shouldBe 2 //dummysession
+        sessionManager.session2loc.size shouldBe 2 //dummysession
+    }
+  }
+
+  "attachProcessorToSession() exist sessionId" should "succeed" in {
+    var resultMap = Map.empty[String, String]
+    List(1,2,3,4,5).par.foreach { x =>
+      val (id, key) = sessionManager.createNewSession() match {
+        case Success((id, key)) => (id, key)
+        case Failure(t) =>
+          t.printStackTrace()
+          fail()
+      }
+      val result = sessionManager.attachProcessorToSession("dummyHost" + x, x, key)
+      result match {
+        case Success(sessionId) =>
+          sessionId shouldBe id
+          sessionManager.session2loc.get(id).get shouldBe ("dummyHost" + x, x)
+        case Failure(t) =>
+          t.printStackTrace()
+          fail()
+      }
+    }
+  }
+  "attachProcessorToSession() non exist sessionId" should "fail" in {
+    val result = sessionManager.attachProcessorToSession("dummyHost", 9999, "NonKey")
+    result match {
+      case Success(sessionId) =>
+        fail()
+      case Failure(t) =>
+        t.getMessage shouldBe(s"non exist sessionId. key: NonKey")
+        sessionManager.key2session.get("NonKey") shouldBe None
+    }
+  }
+  "attachProcessorToSession() sessionStore throw Exception" should "fail" in {
+    val sessionManager = new SessionManager("registerSessionFailed", new DummyStore)
+    val (id, key) = sessionManager.createNewSession() match {
+      case Success((id, key)) => (id, key)
+      case Failure(t) =>
+        t.printStackTrace()
+        fail()
+    }
+    val result = sessionManager.attachProcessorToSession("dummyHost", 9999, key)
+    result match {
+      case Success(sessionId) =>
+        fail()
+      case Failure(t) =>
+        t.getMessage shouldBe("registerSessionFailed")
+        sessionManager.session2loc.get(id) shouldBe None //dummysession
+    }
+  }
+
+  "deleteSession() exist session" should "succeed" in {
+    val sessionManager = new SessionManager("test", new DummyStore)
+    val result = sessionManager.deleteSessionByKey("dummyKey1")
+    result match {
+      case Success((id, key)) =>
+        id shouldBe("dummySession1")
+        key shouldBe("dummyKey1")
+        sessionManager.session2key.get("dummySession1") shouldBe None
+        sessionManager.key2session.get("dummyKey1") shouldBe None
+        sessionManager.session2loc.get("dummySession1") shouldBe None
+      case Failure(t) =>
+        t.printStackTrace()
+        fail()
+    }
+  }
+  "deleteSession() non exist session" should "succeed" in {
+    val result = sessionManager.deleteSessionByKey("dummyKey3")
+    result match {
+      case Success((id, key)) =>
+        id shouldBe(null)
+        key shouldBe("dummyKey3")
+      case Failure(t) =>
+        t.printStackTrace()
+        fail()
+    }
+  }
+  "deleteSession() sessionStore throw Exception" should "fail" in {
+    val sessionManager = new SessionManager("deleteSessionFailed", new DummyStore)
+    val result = sessionManager.deleteSessionByKey("dummyKey1")
+    result match {
+      case Success((id, key)) =>
+        fail()
+      case Failure(t) =>
+        t.getMessage shouldBe("deleteSessionFailed")
+        sessionManager.session2key.get("dummySession1") should not be None //don't delete session cache
+        sessionManager.key2session.get("dummyKey1") should not be None //don't delete session cache
+        sessionManager.session2loc.get("dummySession1") should not be None //don't delete session cache
+    }
+  }
+
+  "deleteSessionById() exist session" should "succeed" in {
+    val sessionManager = new SessionManager("test", new DummyStore)
+    val result = sessionManager.deleteSessionById("dummySession1")
+    result match {
+      case Success((id, key)) =>
+        id shouldBe("dummySession1")
+        key shouldBe("dummyKey1")
+        sessionManager.session2key.get("dummySession1") shouldBe None
+        sessionManager.key2session.get("dummyKey1") shouldBe None
+        sessionManager.session2loc.get("dummySession1") shouldBe None
+      case Failure(t) =>
+        t.printStackTrace()
+        fail()
+    }
+  }
+  "deleteSessionById() non exist session" should "succeed" in {
+    val result = sessionManager.deleteSessionById("dummySession3")
+    result match {
+      case Success((id, key)) =>
+        id shouldBe("dummySession3")
+        key shouldBe(null)
+      case Failure(t) =>
+        t.printStackTrace()
+        fail()
+    }
+  }
+  "deleteSessionById() sessionStore throw Exception" should "fail" in {
+    val sessionManager = new SessionManager("deleteSessionByIdFailed", new DummyStore)
+    val result = sessionManager.deleteSessionById("dummyKey1")
+    result match {
+      case Success((id, key)) =>
+        fail()
+      case Failure(t) =>
+        t.getMessage shouldBe("deleteSessionByIdFailed")
+        sessionManager.session2key.get("dummySession1") should not be None //don't delete session cache
+        sessionManager.key2session.get("dummyKey1") should not be None //don't delete session cache
+        sessionManager.session2loc.get("dummySession1") should not be None //don't delete session cache
+    }
+  }
+
+  "deleteFunction() exist session" should "succeed" in {
+    val sessionManager = new SessionManager("test", new DummyStore)
+    sessionManager.deleteFunction("dummySession1")
+
+    sessionManager.session2key.get("dummySession1") shouldBe None
+    sessionManager.key2session.get("dummyKey1") shouldBe None
+    sessionManager.session2loc.get("dummySession1") shouldBe None
+  }
+  "deleteFunction() non exist session" should "succeed" in {
+    val sessionManager = new SessionManager("test", new DummyStore)
+    sessionManager.deleteFunction("NonSession")
+    //check don't delete
+    sessionManager.session2key.size shouldBe 2
+    sessionManager.key2session.size shouldBe 2
+    sessionManager.session2loc.size shouldBe 2
+  }
+
+  "lock()" should "succeed" in {
+    val lock = sessionManager.lock()
+    lock.lockObject should not be None
+    sessionManager.unlock(lock)
+  }
+  it should "fail" in {
+    val sessionManager = new SessionManager("lockFailed", new DummyStore)
+    try {
+      sessionManager.lock()
+      fail()
+    } catch {
+      case e:Exception =>
+        e.getMessage shouldBe("lockFailed")
+    }
+  }
+
+  "unlock() sessionStore throw Exception" should "succeed" in {
+    val sessionManager = new SessionManager("unLockFailed", new DummyStore)
+    try {
+      val lock = sessionManager.lock()
+      sessionManager.unlock(lock)
+    } catch {
+      case e: Exception =>
+        fail()
+    }
+  }
+
+}

--- a/gateway/src/test/scala/us/jubat/jubaql_server/gateway/UnregisterSpec.scala
+++ b/gateway/src/test/scala/us/jubat/jubaql_server/gateway/UnregisterSpec.scala
@@ -33,12 +33,17 @@ class UnregisterSpec extends FlatSpec with Matchers with GatewayServer with Befo
   val registerJson = write(Register("register", "8.8.8.8", 30)).toString
   val unregisterJson = """{"action": "unregister"}"""
 
-  def requestAsJson(key: String) = {
-    val request = (registrationUrl / key).POST
+  val persist_loginUrl  = :/("localhost", 9880) / "login"
+  val persist_registrationUrl = :/("localhost", 9880) / "registration"
+
+  def requestAsJson(key: String, url: Req = registrationUrl) = {
+    val request = (url / key).POST
     request.setContentType("application/json", "UTF-8")
   }
 
   before {
+    zkServer.restart
+
     // login twice
     for (i <- 0 until 2) {
       val req = Http(loginUrl.POST OK as.String)
@@ -50,6 +55,19 @@ class UnregisterSpec extends FlatSpec with Matchers with GatewayServer with Befo
       val requestWithBody = requestAsJson(key) << registerJson
       Http(requestWithBody OK as.String).option.apply()
     }
+
+    //persist gateway
+    // login twice
+    for (i <- 0 until 2) {
+      val req = Http(persist_loginUrl.POST OK as.String)
+      req.option.apply()
+    }
+
+    // register all keys
+    for (key <- persist_keys) {
+      val requestWithBody = requestAsJson(key, persist_registrationUrl) << registerJson
+      Http(requestWithBody OK as.String).option.apply()
+    }
   }
 
   after {
@@ -58,13 +76,28 @@ class UnregisterSpec extends FlatSpec with Matchers with GatewayServer with Befo
       val requestWithBody = requestAsJson(key) << unregisterJson
       Http(requestWithBody OK as.String).option.apply()
     }
+
+    for (key <- persist_keys) {
+      val requestWithBody = requestAsJson(key, persist_registrationUrl) << unregisterJson
+      Http(requestWithBody OK as.String).option.apply()
+    }
   }
 
   def keys = {
     var keys = List.empty[String]
     // This lock is required because the server is in the same process.
-    plan.session2key.synchronized {
-      for (key <- plan.key2session.keys)
+    plan.sessionManager.session2key.synchronized {
+      for (key <- plan.sessionManager.key2session.keys)
+        keys = key :: keys
+    }
+    keys
+  }
+
+  def persist_keys = {
+    var keys = List.empty[String]
+    // This lock is required because the server is in the same process.
+    persist_plan.sessionManager.session2key.synchronized {
+      for (key <- persist_plan.sessionManager.key2session.keys)
         keys = key :: keys
     }
     keys
@@ -98,16 +131,179 @@ class UnregisterSpec extends FlatSpec with Matchers with GatewayServer with Befo
   "Unregistering an existing key" should "succeed" in {
     for (key <- keys) {
       var sessionId = ""
-      plan.session2key.synchronized {
-        sessionId = plan.key2session.get(key).get
+      plan.sessionManager.session2key.synchronized {
+        sessionId = plan.sessionManager.key2session.get(key).get
       }
       val requestWithBody = requestAsJson(key) << unregisterJson
       Http(requestWithBody OK as.String).option.apply() should not be None
-      plan.session2key.synchronized {
-        plan.session2key.get(sessionId) shouldBe None
-        plan.key2session.get(key) shouldBe None
-        plan.session2loc.get(sessionId) shouldBe None
+      plan.sessionManager.session2key.synchronized {
+        plan.sessionManager.session2key.get(sessionId) shouldBe None
+        plan.sessionManager.key2session.get(key) shouldBe None
+        plan.sessionManager.session2loc.get(sessionId) shouldBe None
       }
     }
+  }
+
+  // persist
+  "Unregistering an existing key in persist" should "succeed" in {
+    persist_keys.par.foreach(key => {
+      var sessionId = ""
+      persist_plan.sessionManager.session2key.synchronized {
+        sessionId = persist_plan.sessionManager.key2session.get(key).get
+      }
+      val requestWithBody = requestAsJson(key, persist_registrationUrl) << unregisterJson
+      Http(requestWithBody OK as.String).option.apply() should not be None
+      persist_plan.sessionManager.session2key.synchronized {
+        persist_plan.sessionManager.session2key.get(sessionId) shouldBe None
+        persist_plan.sessionManager.key2session.get(key) shouldBe None
+        persist_plan.sessionManager.session2loc.get(sessionId) shouldBe None
+        persist_plan.sessionManager.getSessionFromStore(sessionId) shouldBe SessionState.NotFound
+      }
+    })
+  }
+
+  "Unregistering an already delete key in persist" should "succeed" in {
+    persist_keys.par.foreach(key => {
+      var sessionId = ""
+      persist_plan.sessionManager.session2key.synchronized {
+        sessionId = persist_plan.sessionManager.key2session.get(key).get
+      }
+      println("sessionId : " + sessionId+ ", key : " + key)
+      val requestWithBody = requestAsJson(key, persist_registrationUrl) << unregisterJson
+      val result = Http(requestWithBody OK as.String).option.apply()
+      result should not be None
+      result.get shouldBe "Successfully unregistered"
+      persist_plan.sessionManager.session2key.synchronized {
+        persist_plan.sessionManager.session2key.get(sessionId) shouldBe None
+        persist_plan.sessionManager.key2session.get(key) shouldBe None
+        persist_plan.sessionManager.session2loc.get(sessionId) shouldBe None
+        persist_plan.sessionManager.getSessionFromStore(sessionId) shouldBe SessionState.NotFound
+      }
+
+      val alredyDeleteresult = Http(requestWithBody OK as.String).option.apply()
+      alredyDeleteresult should not be None
+      alredyDeleteresult.get shouldBe "Successfully unregistered"
+      persist_plan.sessionManager.session2key.synchronized {
+        persist_plan.sessionManager.session2key.get(sessionId) shouldBe None
+        persist_plan.sessionManager.key2session.get(key) shouldBe None
+        persist_plan.sessionManager.session2loc.get(sessionId) shouldBe None
+        persist_plan.sessionManager.getSessionFromStore(sessionId) shouldBe SessionState.NotFound
+      }
+
+    })
+  }
+
+  "Unregistering connect zookeeper failed in persist" should "fail" in {
+    zkServer.stop
+    persist_keys.par.foreach(key => {
+      var sessionId = ""
+      persist_plan.sessionManager.session2key.synchronized {
+        sessionId = persist_plan.sessionManager.key2session.get(key).get
+      }
+      val requestWithBody = requestAsJson(key, persist_registrationUrl) << unregisterJson
+      val result = Http(requestWithBody).either.apply()
+      result match {
+        case Left(t) =>
+          println("hogehoge---------------------------: " + t.getMessage)
+          fail()
+        case Right(res) =>
+          res.getResponseBody shouldBe s"Failed to unregister key : ${key}"
+          persist_plan.sessionManager.session2key.synchronized {
+            persist_plan.sessionManager.session2key.get(sessionId) should not be None
+            persist_plan.sessionManager.key2session.get(key) should not be None
+            persist_plan.sessionManager.session2loc.get(sessionId) should not be None
+          }
+      }
+    })
+    zkServer.restart
+  }
+
+  "Unregistering an existing key in JubaQLGateway Cluster" should "succeed" in {
+
+    println("--- gateway cluster test setting ---")
+    val gateway1_loginUrl  = :/("localhost", 9980) / "login"
+    val gateway2_loginUrl  = :/("localhost", 9981) / "login"
+    val gateway1_registrationUrl = :/("localhost", 9980) / "registration"
+    val gateway2_registrationUrl = :/("localhost", 9981) / "registration"
+
+    //gateway startup
+    val gateway1_plan = new GatewayPlan("example.com", 2345,
+      Array(), RunMode.Test,
+      sparkDistribution = "",
+      fatjar = "src/test/resources/processor-logfile.jar",
+      checkpointDir = "file:///tmp/spark", "gateway_cluster", true)
+    val gateway1_server = unfiltered.netty.Server.http(9980).plan(gateway1_plan)
+    gateway1_server.start
+
+    // login
+    for (i <- 0 until 2) {
+      val req = Http(gateway1_loginUrl.POST OK as.String)
+      req.option.apply()
+    }
+    // get key
+    var keys = List.empty[String]
+    gateway1_plan.sessionManager.session2key.synchronized {
+      for (key <- gateway1_plan.sessionManager.key2session.keys)
+        keys = key :: keys
+    }
+    // register all keys
+    for (key <- keys) {
+      val requestWithBody = requestAsJson(key, gateway1_registrationUrl) << registerJson
+      val res = Http(requestWithBody OK as.String).option.apply()
+    }
+
+    //gateway1でregistrationが完了した時点で同クラスタに所属するgateway2を起動
+    val gateway2_plan = new GatewayPlan("example.com", 2346,
+      Array(), RunMode.Test,
+      sparkDistribution = "",
+      fatjar = "src/test/resources/processor-logfile.jar",
+      checkpointDir = "file:///tmp/spark", "gateway_cluster", true)
+    val gateway2_server = unfiltered.netty.Server.http(9981).plan(gateway2_plan)
+    gateway2_server.start
+
+    keys.par.foreach(key => {
+      var sessionId = ""
+      gateway1_plan.sessionManager.session2key.synchronized {
+        sessionId = gateway1_plan.sessionManager.key2session.get(key).get
+      }
+      gateway1_plan.sessionManager.session2key.synchronized {
+        gateway1_plan.sessionManager.session2key.get(sessionId) should not be None
+        gateway1_plan.sessionManager.key2session.get(key) should not be None
+        gateway1_plan.sessionManager.session2loc.get(sessionId) should not be None
+        gateway1_plan.sessionManager.getSessionFromStore(sessionId).isInstanceOf[SessionState.Ready] shouldBe true
+      }
+      gateway2_plan.sessionManager.session2key.synchronized {
+        gateway2_plan.sessionManager.session2key.get(sessionId) should not be None
+        gateway2_plan.sessionManager.key2session.get(key) should not be None
+        gateway2_plan.sessionManager.session2loc.get(sessionId) should not be None
+        gateway2_plan.sessionManager.getSessionFromStore(sessionId).isInstanceOf[SessionState.Ready] shouldBe true
+      }
+    })
+    println("--- unregistring ---")
+    keys.par.foreach(key => {
+      var sessionId = ""
+      gateway1_plan.sessionManager.session2key.synchronized {
+        sessionId = gateway1_plan.sessionManager.key2session.get(key).get
+      }
+      // セッション情報を登録したgateway以外でunregeister実行
+      val requestWithBody = requestAsJson(key, gateway2_registrationUrl) << unregisterJson
+      Http(requestWithBody OK as.String).option.apply() should not be None
+      // 同クラスタのすべてのgatewayから該当セッション情報が削除されることを確認
+      gateway1_plan.sessionManager.session2key.synchronized {
+        gateway1_plan.sessionManager.session2key.get(sessionId) shouldBe None
+        gateway1_plan.sessionManager.key2session.get(key) shouldBe None
+        gateway1_plan.sessionManager.session2loc.get(sessionId) shouldBe None
+        gateway1_plan.sessionManager.getSessionFromStore(sessionId) shouldBe SessionState.NotFound
+      }
+      gateway2_plan.sessionManager.session2key.synchronized {
+        gateway2_plan.sessionManager.session2key.get(sessionId) shouldBe None
+        gateway2_plan.sessionManager.key2session.get(key) shouldBe None
+        gateway2_plan.sessionManager.session2loc.get(sessionId) shouldBe None
+        gateway2_plan.sessionManager.getSessionFromStore(sessionId) shouldBe SessionState.NotFound
+      }
+    })
+    println("--- unregistred ---")
+    gateway1_server.stop
+    gateway2_server.stop
   }
 }

--- a/gateway/src/test/scala/us/jubat/jubaql_server/gateway/ZookeeperServer.scala
+++ b/gateway/src/test/scala/us/jubat/jubaql_server/gateway/ZookeeperServer.scala
@@ -1,0 +1,36 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2015 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+package us.jubat.jubaql_server.gateway
+
+import org.scalatest.{Suite, BeforeAndAfterAll, BeforeAndAfter}
+import org.apache.curator.test.TestingServer
+
+trait ZookeeperServer extends BeforeAndAfter with BeforeAndAfterAll {
+  this: Suite =>
+
+  val zkServer = new TestingServer(2181, true)
+
+  before {
+    zkServer.restart()
+  }
+  after {
+    zkServer.stop()
+  }
+
+  override protected def afterAll() {
+    zkServer.close()
+  }
+}

--- a/gateway/src/test/scala/us/jubat/jubaql_server/gateway/ZookeeperStoreSpec.scala
+++ b/gateway/src/test/scala/us/jubat/jubaql_server/gateway/ZookeeperStoreSpec.scala
@@ -1,0 +1,468 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2015 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+package us.jubat.jubaql_server.gateway
+
+import org.scalatest._
+import scala.util._
+import java.util.concurrent.locks.ReentrantLock
+
+class ZookeeperStoreSpec extends FlatSpec with Matchers with ZookeeperServer {
+  val zkStore = new ZookeeperStore()
+
+  var res: String = ""
+  var res2: String = ""
+
+  "getAllSessions() NoNode" should "succeed" in {
+    val result = zkStore.getAllSessions("NoNode")
+    result.size shouldBe (0)
+  }
+
+  "getAllSessions() Empty" should "succeed" in {
+    zkStore.registerGateway("getAllSessions")
+    val result = zkStore.getAllSessions("getAllSessions")
+    result.size shouldBe (0)
+  }
+
+  "getAllSessions() Size=2" should "succeed" in {
+    zkStore.registerGateway("getAllSessions")
+    // set ReadySession
+    zkStore.preregisterSession("getAllSessions", "sessionID1", "DummyKey1")
+    zkStore.registerSession("getAllSessions", "sessionID1", "DummyHost1", 9999, "DummyKey1")
+    // set RegisteringSession
+    zkStore.preregisterSession("getAllSessions", "sessionID2", "DummyKey2")
+
+    val result = zkStore.getAllSessions("getAllSessions")
+    result.size shouldBe (2)
+    result.get("sessionID1") should not be None
+    result.get("sessionID1").get.isInstanceOf[SessionState.Ready] shouldBe (true)
+    val getSession1 = result.get("sessionID1").get.asInstanceOf[SessionState.Ready]
+    getSession1.host shouldBe "DummyHost1"
+    getSession1.port shouldBe 9999
+    getSession1.key shouldBe "DummyKey1"
+    result.get("sessionID2") should not be None
+    result.get("sessionID2").get.isInstanceOf[SessionState.Registering] shouldBe (true)
+    val getSession2 = result.get("sessionID2").get.asInstanceOf[SessionState.Registering]
+    getSession2.key shouldBe "DummyKey2"
+  }
+
+  "getAllSessions() stop zookeeper" should "fail" in {
+    zkStore.registerGateway("getAllSessions")
+    zkServer.stop()
+    try {
+      zkStore.getAllSessions("getAllSessions")
+      fail
+    } catch {
+      case e: Exception =>
+        e.getMessage shouldBe ("failed to get all session.")
+    }
+  }
+
+  "getSession() non exist SessionNode" should "succeed" in {
+    zkStore.registerGateway("getSession")
+    val result = zkStore.getSession("getSession", "NoSession")
+    result shouldBe (SessionState.NotFound)
+  }
+
+  "getSession() exist SessionNode" should "succeed" in {
+    zkStore.registerGateway("getSession")
+    // set ReadySession
+    zkStore.preregisterSession("getSession", "sessionID1", "DummyKey1")
+    zkStore.registerSession("getSession", "sessionID1", "DummyHost1", 9999, "DummyKey1")
+    // set RegisteringSession
+    zkStore.preregisterSession("getSession", "sessionID2", "DummyKey2")
+    // set InconsistantSession
+    zkStore.zookeeperClient.create().forPath(s"${zkStore.zkSessionPath}/getSession/sessionID3", s"""{"host":"DummyHost3", "port": 9999}""".getBytes("UTF-8"))
+
+    val result1 = zkStore.getSession("getSession", "sessionID1")
+    val getSession1 = result1.asInstanceOf[SessionState.Ready]
+    getSession1.host shouldBe "DummyHost1"
+    getSession1.port shouldBe 9999
+    getSession1.key shouldBe "DummyKey1"
+    val result2 = zkStore.getSession("getSession", "sessionID2")
+    val getSession2 = result2.asInstanceOf[SessionState.Registering]
+    getSession2.key shouldBe "DummyKey2"
+    val result3 = zkStore.getSession("getSession", "sessionID3")
+    result3 shouldBe (SessionState.Inconsistent)
+    val result4 = zkStore.getSession("getSession", "sessionID4")
+    result4 shouldBe (SessionState.NotFound)
+  }
+
+  "getSession() illegal data" should "fail" in {
+    zkStore.registerGateway("getSession")
+    zkStore.zookeeperClient.create().forPath(s"${zkStore.zkSessionPath}/getSession/IllegalData", s"""{"host":"DummyHost", "port": "number", "key": "DummyKey"}""".getBytes("UTF-8"))
+
+    try {
+      zkStore.getSession("getSession", "IllegalData")
+      fail
+    } catch {
+      case e: Exception =>
+        e.getMessage shouldBe ("failed to get session. sessionId: IllegalData")
+    }
+  }
+
+  "preregisterSession() non exist SessionNode" should "succeed" in {
+    zkStore.registerGateway("preregisterSession")
+    zkStore.preregisterSession("preregisterSession", "sessionID1", "DummyKey")
+    val result = zkStore.getSession("preregisterSession", "sessionID1")
+    result.isInstanceOf[SessionState.Registering] shouldBe (true)
+    val session = result.asInstanceOf[SessionState.Registering]
+    session.key shouldBe ("DummyKey")
+  }
+
+  "preregisterSession() already exist SessionNode" should "fail" in {
+    zkStore.registerGateway("preregisterSession")
+    zkStore.preregisterSession("preregisterSession", "sessionID2", "DummyKey")
+    try {
+      zkStore.preregisterSession("preregisterSession", "sessionID2", "DummyKey2")
+    } catch {
+      case e: Exception =>
+        e.getMessage shouldBe ("failed to pre-register session. sessionId: sessionID2")
+        // 先に登録したデータに影響がないことを確認
+        val result = zkStore.getSession("preregisterSession", "sessionID2")
+        result.isInstanceOf[SessionState.Registering] shouldBe (true)
+        val session = result.asInstanceOf[SessionState.Registering]
+        session.key shouldBe ("DummyKey")
+    }
+  }
+
+  "preregisterSession() stop zookeeper" should "fail" in {
+    zkStore.registerGateway("preregisterSession")
+    zkServer.stop()
+    try {
+      zkStore.preregisterSession("preregisterSession", "sessionID3", "DummyKey")
+      fail
+    } catch {
+      case e: Exception =>
+        e.getMessage shouldBe ("failed to pre-register session. sessionId: sessionID3")
+    }
+  }
+
+  "registerSession() non exist SessionNode" should "fail" in {
+    zkStore.registerGateway("registerSession")
+    try {
+      zkStore.registerSession("registerSession", "sessionID1", "DummyHost", 9999, "DummyKey")
+    } catch {
+      case e: Exception =>
+        e.getMessage shouldBe ("failed to register session. sessionId: sessionID1")
+        val result = zkStore.getSession("registerSession", "sessionID1")
+        result shouldBe SessionState.NotFound
+    }
+  }
+
+  "registerSession() exist SessionNode" should "fail" in {
+    zkStore.registerGateway("registerSession")
+    zkStore.preregisterSession("registerSession", "sessionID2", "DummyKey")
+    zkStore.registerSession("registerSession", "sessionID2", "DummyHost2", 9999, "DummyKey2")
+    val result = zkStore.getSession("registerSession", "sessionID2")
+    val getSession = result.asInstanceOf[SessionState.Ready]
+    getSession.host shouldBe "DummyHost2"
+    getSession.port shouldBe 9999
+    getSession.key shouldBe "DummyKey2"
+  }
+
+  "registerSession() alreadyRegistered SessionNode" should "fail" in {
+    zkStore.registerGateway("registerSession")
+    zkStore.preregisterSession("registerSession", "sessionID3", "DummyKey")
+    zkStore.registerSession("registerSession", "sessionID3", "DummyHost3", 9999, "DummyKey3")
+
+    try {
+      zkStore.registerSession("registerSession", "sessionID3", "DummyHost4", 9999, "DummyKey4")
+    } catch {
+      case e: Exception =>
+        e.getMessage shouldBe ("failed to register session. sessionId: sessionID3")
+        val result = zkStore.getSession("registerSession", "sessionID3")
+        val getSession = result.asInstanceOf[SessionState.Ready]
+        getSession.host shouldBe "DummyHost3"
+        getSession.port shouldBe 9999
+        getSession.key shouldBe "DummyKey3"
+    }
+  }
+
+  "registerSession() stop zookeeper" should "fail" in {
+    zkStore.registerGateway("registerSession")
+    zkStore.preregisterSession("registerSession", "sessionID4", "DummyKey")
+
+    zkServer.stop
+    try {
+      zkStore.registerSession("registerSession", "sessionID4", "DummyHost4", 9999, "DummyKey4")
+    } catch {
+      case e: Exception =>
+        e.getMessage shouldBe ("failed to register session. sessionId: sessionID4")
+    }
+  }
+
+  "deleteSession() non exist SessionNode" should "succeed" in {
+    zkStore.registerGateway("deleteSession")
+    try {
+      zkStore.deleteSession("deleteSession", "sessionID1")
+    } catch {
+      case e: Exception =>
+        e.printStackTrace()
+        fail
+    }
+  }
+
+  "deleteSession() exist Registering SessionNode" should "succeed" in {
+    zkStore.registerGateway("deleteSession")
+    zkStore.preregisterSession("deleteSession", "sessionID1", "DummyKey1")
+
+    zkStore.deleteSession("deleteSession", "sessionID1")
+    val result = zkStore.getSession("deleteSession", "sessionID1")
+    result shouldBe (SessionState.NotFound)
+  }
+
+  "deleteSession() exist Registered SessionNode" should "succeed" in {
+    zkStore.registerGateway("deleteSession")
+    zkStore.preregisterSession("deleteSession", "sessionID2", "DummyKey2")
+    zkStore.registerSession("deleteSession", "sessionID2", "DummyHost2", 9999, "DummyKey2")
+
+    zkStore.deleteSession("deleteSession", "sessionID2")
+    val result = zkStore.getSession("deleteSession", "sessionID2")
+    result shouldBe (SessionState.NotFound)
+  }
+
+  "deleteSession() stop zookeeper" should "fail" in {
+    zkStore.registerGateway("deleteSession")
+    zkStore.preregisterSession("deleteSession", "sessionID3", "DummyKey3")
+    zkServer.stop
+
+    try {
+      zkStore.deleteSession("deleteSession", "sessionID3")
+      fail
+    } catch {
+      case e: Exception =>
+        e.getMessage shouldBe ("failed to delete session. sessionId: sessionID3")
+    }
+  }
+
+  "lock() non exist SessionNode" should "succeed" in {
+    val result = zkStore.lock("lock")
+    result should not be null
+    zkStore.unlock(result)
+  }
+
+  "lock() exist SessionNode" should "succeed" in {
+    zkStore.registerGateway("lock")
+    val result = zkStore.lock("lock")
+    result should not be null
+    zkStore.unlock(result)
+  }
+
+  //  "lock() mulitlock timeout" should "succeed" in {
+  //    // 多重ロック＋ロックタイムアウトの確認
+  //    // lockTimeout時間待ち合わせるため、実行する場合は、定数を変更する。
+  //    zkStore.registerGateway("lock")
+  //      val result = zkStore.lock("lock")
+  //      result should not be null
+  //      val result2 = zkStore.lock("lock")
+  //      result2 should not be null
+  //      zkStore.unlock(result2)
+  //  }
+
+  "lock() stop zookeeper" should "fail" in {
+    zkStore.registerGateway("lock")
+    zkServer.stop
+    try {
+      zkStore.lock("lock")
+      fail
+    } catch {
+      case e: Exception =>
+        e.getMessage shouldBe ("failed to create lock object. gatewayId: lock")
+    }
+  }
+
+  "unlock() sessionLock null" should "fail" in {
+    zkStore.registerGateway("unlock")
+    try {
+      zkStore.unlock(null)
+    } catch {
+      case e: Exception =>
+        e.getMessage shouldBe ("failed to unlock. session lock: null")
+    }
+  }
+
+  "unlock() lockObject null" should "fail" in {
+    zkStore.registerGateway("unlock")
+    val sessionLock = new SessionLock(null)
+    try {
+      zkStore.unlock(sessionLock)
+    } catch {
+      case e: Exception =>
+        e.getMessage shouldBe ("failed to unlock. lock object: null")
+    }
+  }
+  "unlock() illegal parameter" should "fail" in {
+    zkStore.registerGateway("unlock")
+    val illegalLockObj = new ReentrantLock()
+    val sessionLock = new SessionLock(illegalLockObj)
+    try {
+      zkStore.unlock(sessionLock)
+    } catch {
+      case e: Exception =>
+        e.getMessage shouldBe ("failed to unlock. illegal lock object: class java.util.concurrent.locks.ReentrantLock")
+    }
+  }
+
+  "unlock() stop zookeeper" should "fail" in {
+    zkStore.registerGateway("unlock")
+    val lockObj = zkStore.lock("unlock")
+    zkServer.stop
+    try {
+      zkStore.unlock(lockObj)
+      fail
+    } catch {
+      case e: Exception =>
+        e.getMessage shouldBe ("failed to unlock")
+    }
+  }
+
+  "addDeleteListener() add Session" should "succeed" in {
+    res = ""
+    zkStore.registerGateway("addDeleteListener")
+    zkStore.preregisterSession("addDeleteListener", "sessionID1", "dummyKey1")
+
+    zkStore.addDeleteListener("addDeleteListener", "sessionID1", (str: String) =>
+      {
+        res = str
+        println(s"call Dummy Delete Function. sessionId: ${str}")
+        fail()
+      })
+    zkStore.deleteSession("addDeleteListener", "sessionID1")
+    //削除イベント処理待ち
+    Thread.sleep(1000)
+    res shouldBe ("sessionID1")
+  }
+
+  "addDeleteListener() deleted Session" should "succeed" in {
+    res = ""
+    zkStore.registerGateway("addDeleteListener")
+    zkStore.preregisterSession("addDeleteListener", "sessionID1", "dummyKey1")
+    zkStore.addDeleteListener("addDeleteListener", "sessionID1", (str: String) =>
+      {
+        res = str
+        println(s"call Dummy Delete Function. sessionId: ${str}")
+      })
+    zkStore.deleteSession("addDeleteListener", "sessionID1")
+    //削除イベント処理待ち
+    Thread.sleep(1000)
+    res shouldBe ("sessionID1")
+    zkStore.deleteSession("addDeleteListener", "sessionID1")
+  }
+
+  "addDeleteListener() add Multi Session" should "succeed" in {
+    res = ""
+    res2 = ""
+    zkStore.registerGateway("addDeleteListener")
+    zkStore.preregisterSession("addDeleteListener", "sessionID1", "dummyKey1")
+    zkStore.preregisterSession("addDeleteListener", "sessionID2", "dummyKey2")
+    zkStore.registerSession("addDeleteListener", "sessionID2", "dummyHost2", 9999, "dummyKey2")
+
+    zkStore.addDeleteListener("addDeleteListener", "sessionID1", (str: String) =>
+      {
+        res = str
+        println(s"call Dummy Delete Function1. sessionId: ${str}")
+      })
+    zkStore.addDeleteListener("addDeleteListener", "sessionID2", (str: String) =>
+      {
+        res2 = str
+        println(s"call Dummy Delete Function2. sessionId: ${str}")
+      })
+    zkStore.deleteSession("addDeleteListener", "sessionID1")
+    //削除イベント処理待ち
+    Thread.sleep(1000)
+    res shouldBe ("sessionID1")
+    res2 shouldBe ("")
+  }
+
+  "addDeleteListener() Re add Session" should "succeed" in {
+    zkStore.registerGateway("addDeleteListener")
+    zkStore.preregisterSession("addDeleteListener", "sessionID1", "dummyKey1")
+    zkStore.addDeleteListener("addDeleteListener", "sessionID1", (str: String) =>
+      {
+        res = str
+        println(s"call Dummy Delete Function. sessionId: ${str}")
+      })
+    zkStore.deleteSession("addDeleteListener", "sessionID1")
+    //削除イベント処理待ち
+    Thread.sleep(1000)
+    res shouldBe ("sessionID1")
+
+    //Re: add deleteListener
+    zkStore.preregisterSession("addDeleteListener", "sessionID1", "dummyKey1")
+    res = ""
+    zkStore.addDeleteListener("addDeleteListener", "sessionID1", (str: String) =>
+      {
+        res = str
+        println(s"call Dummy Delete Function. sessionId: ${str}")
+      })
+    zkStore.deleteSession("addDeleteListener", "sessionID1")
+    //削除イベント処理待ち
+    Thread.sleep(1000)
+    res shouldBe ("sessionID1")
+  }
+
+  "addDeleteListener() exclude SessionId" should "succeed" in {
+    res = ""
+    zkStore.registerGateway("addDeleteListener")
+    zkStore.zookeeperClient.create().forPath(s"${zkStore.zkSessionPath}/addDeleteListener/locks", """""".getBytes("UTF-8"))
+    zkStore.addDeleteListener("addDeleteListener", "locks", (str: String) =>
+      {
+        res = str
+        println(s"call Dummy Delete Function. sessionId: ${str}")
+      })
+    zkStore.deleteSession("addDeleteListener", "locks")
+    //削除イベント処理待ち
+    Thread.sleep(1000)
+    res shouldBe ("")
+
+    zkStore.zookeeperClient.create().forPath(s"${zkStore.zkSessionPath}/addDeleteListener/leases", """""".getBytes("UTF-8"))
+    res = ""
+    zkStore.addDeleteListener("addDeleteListener", "leases", (str: String) =>
+      {
+        res = str
+        println(s"call Dummy Delete Function. sessionId: ${str}")
+      })
+    zkStore.deleteSession("addDeleteListener", "leases")
+    //削除イベント処理待ち
+    Thread.sleep(1000)
+    res shouldBe ("")
+  }
+
+  "addDeleteListener() stop zookeeper" should "fail" in {
+    zkStore.registerGateway("addDeleteListener")
+    zkServer.stop
+    try {
+      val str = "hoge"
+      zkStore.addDeleteListener("addDeleteListener", "sessionID1", (str: String) => { println(s"Dummy Delete Function:${str}") })
+      fail
+    } catch {
+      case e: Exception =>
+        e.getMessage shouldBe ("failed to add delete listener. sessionId: sessionID1")
+    }
+  }
+
+  "registerGateway() stop zookeeper" should "fail" in {
+    zkServer.stop
+    try {
+      zkStore.registerGateway("registerGateway")
+      fail
+    } catch {
+      case e: Exception =>
+        e.getMessage shouldBe ("failed to registerGateway. gatewayId: registerGateway")
+    }
+  }
+
+}

--- a/processor/build.sbt
+++ b/processor/build.sbt
@@ -31,7 +31,7 @@ libraryDependencies ++= Seq(
   "org.slf4j"                  %  "slf4j-api"              % "1.6.4",
   "org.slf4j"                  %  "slf4j-log4j12"          % "1.6.4",
   // Jubatus
-  "us.jubat"                   % "jubatus"                 % "0.7.1"
+  "us.jubat"                   % "jubatus"                 % "0.8.0"
             exclude("org.jboss.netty", "netty"),
   // jubatusonyarn
   "us.jubat"                   %% "jubatus-on-yarn-client"    % "1.1"

--- a/processor/src/main/scala/us/jubat/jubaql_server/processor/JubaQLAST.scala
+++ b/processor/src/main/scala/us/jubat/jubaql_server/processor/JubaQLAST.scala
@@ -75,3 +75,7 @@ case class CreateFeatureFunction(funcName: String, args: List[(String, String)],
 
 case class CreateTriggerFunction(funcName: String, args: List[(String, String)],
                                  lang: String, body: String) extends JubaQLAST
+
+case class SaveModel(modelName: String, modelPath: String, modelId: String) extends JubaQLAST
+
+case class LoadModel(modelName: String, modelPath: String, modelId: String) extends JubaQLAST

--- a/processor/src/main/scala/us/jubat/jubaql_server/processor/JubaQLParser.scala
+++ b/processor/src/main/scala/us/jubat/jubaql_server/processor/JubaQLParser.scala
@@ -111,6 +111,9 @@ class JubaQLParser extends SqlParser with LazyLogging {
   protected lazy val TIME = Keyword("TIME")
   protected lazy val TUPLES = Keyword("TUPLES")
   protected lazy val OVER = Keyword("OVER")
+  protected lazy val SAVE = Keyword("SAVE")
+  protected lazy val ID = Keyword("ID")
+  protected lazy val LOAD = Keyword("LOAD")
 
   override val lexical = new JubaQLLexical(reservedWords)
 
@@ -369,6 +372,30 @@ class JubaQLParser extends SqlParser with LazyLogging {
     }
   }
 
+  protected lazy val saveModel: Parser[JubaQLAST] = {
+    SAVE ~ MODEL ~> modelIdent ~ USING ~ stringLit ~ WITH ~ ID ~ "=" ~ ident ^^ {
+      case modelName ~ _ ~ modelPath ~ _ ~ _ ~ _ ~ modelId =>
+        modelPath match {
+          case "" =>
+            null
+          case _ =>
+            SaveModel(modelName, modelPath, modelId)
+        }
+    }
+  }
+
+  protected lazy val loadModel: Parser[JubaQLAST] = {
+    LOAD ~ MODEL ~> modelIdent ~ USING ~ stringLit ~ WITH ~ ID ~ "=" ~ ident ^^ {
+      case modelName ~ _ ~ modelPath ~ _ ~ _ ~ _ ~ modelId =>
+        modelPath match {
+          case "" =>
+            null
+          case _ =>
+            LoadModel(modelName, modelPath, modelId)
+        }
+    }
+  }
+
   protected lazy val jubaQLQuery: Parser[JubaQLAST] = {
     createDatasource |
       createModel |
@@ -385,7 +412,9 @@ class JubaQLParser extends SqlParser with LazyLogging {
       stopProcessing |
       createFunction |
       createFeatureFunction |
-      createTriggerFunction
+      createTriggerFunction |
+      saveModel |
+      loadModel
   }
 
   // note: apply cannot override incompatible type with parent class

--- a/processor/src/main/scala/us/jubat/jubaql_server/processor/JubaQLService.scala
+++ b/processor/src/main/scala/us/jubat/jubaql_server/processor/JubaQLService.scala
@@ -19,6 +19,7 @@ import java.net.InetAddress
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.concurrent.ConcurrentHashMap
+import collection.JavaConversions._
 
 import com.twitter.finagle.Service
 import com.twitter.util.{Future => TwFuture, Promise => TwPromise}
@@ -27,6 +28,7 @@ import io.netty.util.CharsetUtil
 import RunMode.{Production, Development}
 import us.jubat.jubaql_server.processor.json._
 import us.jubat.jubaql_server.processor.updater._
+import org.apache.hadoop.conf.Configuration
 import org.apache.spark.{SparkFiles, SparkContext}
 import org.apache.spark.SparkContext._
 import org.apache.spark.rdd.RDD
@@ -44,10 +46,11 @@ import org.jboss.netty.handler.codec.http._
 import org.json4s._
 import org.json4s.native.{JsonMethods, Serialization}
 import org.json4s.JsonDSL._
+import org.apache.commons.io._
 import sun.misc.Signal
 import us.jubat.anomaly.AnomalyClient
 import us.jubat.classifier.ClassifierClient
-import us.jubat.common.Datum
+import us.jubat.common.{Datum, ClientBase}
 import us.jubat.recommender.RecommenderClient
 import us.jubat.yarn.client.{JubatusYarnApplication, JubatusYarnApplicationStatus, Resource}
 import us.jubat.yarn.common.{LearningMachineType, Location}
@@ -325,12 +328,17 @@ class JubaQLService(sc: SparkContext, runMode: RunMode, checkpointDir: String)
         }
         // TODO: location, resource
         val resource = Resource(priority = 0, memory = 256, virtualCores = 1)
+
+        val gatewayAddress = scala.util.Properties.propOrElse("jubaql.gateway.address","")
+        val sessionId = scala.util.Properties.propOrElse("jubaql.processor.sessionId","")
+        val applicationName = s"JubatusOnYarn:$gatewayAddress:$sessionId:${jubaType.name}:${cm.modelName}"
+
         val juba: ScFuture[JubatusYarnApplication] = runMode match {
           case RunMode.Production(zookeeper) =>
             val location = zookeeper.map {
               case (host, port) => Location(InetAddress.getByName(host), port)
             }
-            JubatusYarnApplication.start(cm.modelName, jubaType, location, configJsonStr, resource, 2)
+            JubatusYarnApplication.start(cm.modelName, jubaType, location, configJsonStr, resource, 2, applicationName)
           case RunMode.Development =>
             LocalJubatusApplication.start(cm.modelName, jubaType, configJsonStr)
         }
@@ -1164,8 +1172,74 @@ class JubaQLService(sc: SparkContext, runMode: RunMode, checkpointDir: String)
             Left((400, msg))
         }
 
+      case SaveModel(modelName, modelPath, modelId) =>
+        models.get(modelName) match {
+          case Some((jubaApp, createModelStmt, machineType)) =>
+            val chkResult = runMode match {
+              case RunMode.Production(zookeeper) =>
+                modelPath.startsWith("hdfs://")
+              case RunMode.Development =>
+                modelPath.startsWith("file://")
+            }
+
+            if (chkResult) {
+              val juba = jubaApp.saveModel(new org.apache.hadoop.fs.Path(modelPath), modelId)
+              juba match {
+                case Failure(t) =>
+                  val msg = s"SAVE MODEL failed: ${t.getMessage}"
+                  logger.error(msg, t)
+                  Left((500, msg))
+
+                case _ =>
+                  Right(StatementProcessed("SAVE MODEL"))
+              }
+            } else {
+              val msg = s"invalid model path ($modelPath)"
+              logger.warn(msg)
+              Left((400, msg))
+            }
+
+          case None =>
+            val msg = s"model '$modelName' does not exist"
+            logger.warn(msg)
+            Left((400, msg))
+        }
+
+      case LoadModel(modelName, modelPath, modelId) =>
+        models.get(modelName) match {
+          case Some((jubaApp, createModelStmt, machineType)) =>
+            val chkResult = runMode match {
+              case RunMode.Production(zookeeper) =>
+                modelPath.startsWith("hdfs://")
+              case RunMode.Development =>
+                modelPath.startsWith("file://")
+            }
+
+            if (chkResult) {
+              val juba = jubaApp.loadModel(new org.apache.hadoop.fs.Path(modelPath), modelId)
+              juba match {
+                case Failure(t) =>
+                  val msg = s"LOAD MODEL failed: ${t.getMessage}"
+                  logger.error(msg, t)
+                  Left((500, msg))
+
+                case _ =>
+                  Right(StatementProcessed("LOAD MODEL"))
+              }
+            } else {
+              val msg = s"invalid model path ($modelPath)"
+              logger.warn(msg)
+              Left((400, msg))
+            }
+
+          case None =>
+            val msg = s"model '$modelName' does not exist"
+            logger.warn(msg)
+            Left((400, msg))
+        }
+
       case other =>
-        val msg = "no handler for " + other
+        val msg = s"no handler for $other"
         logger.error(msg)
         Left((500, msg))
     }
@@ -1511,8 +1585,8 @@ object LocalJubatusApplication extends LazyLogging {
           namedPipeWriter.close()
         }
 
-        new LocalJubatusApplication(jubatusProcess, aLearningMachineName, jubaCmdName,
-          rpcPort)
+        new LocalJubatusApplication(jubatusProcess, aLearningMachineName, aLearningMachineType,
+            jubaCmdName, rpcPort)
       } finally {
         namedPipe.delete()
       }
@@ -1566,8 +1640,11 @@ object LocalJubatusApplication extends LazyLogging {
 }
 
 // LocalJubatusApplication is not a JubatusYarnApplication, but extends JubatusYarnApplication for implementation.
-class LocalJubatusApplication(jubatus: Process, name: String, jubaCmdName: String, port: Int = 9199)
+class LocalJubatusApplication(jubatus: Process, name: String, aLearningMachineType: LearningMachineType, jubaCmdName: String, port: Int = 9199)
   extends JubatusYarnApplication(Location(InetAddress.getLocalHost, port), List(), null) {
+
+  private val timeoutCount: Int = 180
+  private val fileRe = """file://(.+)""".r
 
   override def status: JubatusYarnApplicationStatus = {
     throw new NotImplementedError("status is not implemented")
@@ -1585,10 +1662,136 @@ class LocalJubatusApplication(jubatus: Process, name: String, jubaCmdName: Strin
   }
 
   override def loadModel(aModelPathPrefix: org.apache.hadoop.fs.Path, aModelId: String): Try[JubatusYarnApplication] = Try {
-    throw new NotImplementedError("loadModel is not implemented")
+    logger.info(s"loadModel path: $aModelPathPrefix, modelId: $aModelId")
+
+    val strHost = jubatusProxy.hostAddress
+    val strPort = jubatusProxy.port
+
+    val srcDir = aModelPathPrefix.toUri().toString() match {
+      case fileRe(filepath) =>
+        val realpath = if (filepath.startsWith("/")) {
+          filepath
+        } else {
+          (new java.io.File(".")).getAbsolutePath + "/" + filepath
+        }
+        "file://" + realpath
+    }
+    logger.debug(s"convert srcDir: $srcDir")
+
+    val localFileSystem = org.apache.hadoop.fs.FileSystem.getLocal(new Configuration())
+    val srcDirectory = localFileSystem.pathToFile(new org.apache.hadoop.fs.Path(srcDir))
+    val srcPath = new java.io.File(srcDirectory, aModelId)
+    if (!srcPath.exists()) {
+      val msg = s"model path does not exist ($srcPath)"
+      logger.error(msg)
+      throw new RuntimeException(msg)
+    }
+
+    val srcFile = new java.io.File(srcPath, "0.jubatus")
+    if (!srcFile.exists()) {
+      val msg = s"model file does not exist ($srcFile)"
+      logger.error(msg)
+      throw new RuntimeException(msg)
+    }
+
+    val client: ClientBase = aLearningMachineType match {
+      case LearningMachineType.Anomaly =>
+        new AnomalyClient(strHost, strPort, name, timeoutCount)
+
+      case LearningMachineType.Classifier =>
+        new ClassifierClient(strHost, strPort, name, timeoutCount)
+
+      case LearningMachineType.Recommender =>
+        new RecommenderClient(strHost, strPort, name, timeoutCount)
+    }
+
+    val stsMap: Map[String, java.util.Map[String, String]] = client.getStatus()
+    logger.debug(s"getStatus method result: $stsMap")
+    if (stsMap.size != 1) {
+      val msg = s"getStatus RPC failed (got ${stsMap.size} results)"
+      logger.error(msg)
+      throw new RuntimeException(msg)
+    }
+
+    val strHostPort = stsMap.keys.head
+    logger.debug(s"key[Host_Port]: $strHostPort")
+
+    val baseDir = localFileSystem.pathToFile(new org.apache.hadoop.fs.Path(stsMap.get(strHostPort).get("datadir")))
+    val mType = stsMap.get(strHostPort).get("type")
+    val dstFile = new java.io.File(baseDir, s"${strHostPort}_${mType}_${aModelId}.jubatus")
+
+    logger.debug(s"srcFile: $srcFile")
+    logger.debug(s"dstFile: $dstFile")
+
+    FileUtils.copyFile(srcFile, dstFile, false)
+
+    val ret = client.load(aModelId)
+    if (!ret) {
+      val msg = "load RPC failed"
+      logger.error(msg)
+      throw new RuntimeException(msg)
+    }
+    this
   }
 
   override def saveModel(aModelPathPrefix: org.apache.hadoop.fs.Path, aModelId: String): Try[JubatusYarnApplication] = Try {
-    throw new NotImplementedError("saveModel is not implemented")
+    logger.info(s"saveModel path: $aModelPathPrefix, modelId: $aModelId")
+
+    val strHost = jubatusProxy.hostAddress
+    val strPort = jubatusProxy.port
+
+    val strId = Math.abs(new Random().nextInt()).toString()
+
+    val result: Map[String, String] = aLearningMachineType match {
+      case LearningMachineType.Anomaly =>
+        val anomaly = new AnomalyClient(strHost, strPort, name, timeoutCount)
+        anomaly.save(strId)
+
+      case LearningMachineType.Classifier =>
+        val classifier = new ClassifierClient(strHost, strPort, name, timeoutCount)
+        classifier.save(strId)
+
+      case LearningMachineType.Recommender =>
+        val recommender = new RecommenderClient(strHost, strPort, name, timeoutCount)
+        recommender.save(strId)
+    }
+
+    logger.debug(s"save method result: $result")
+    if (result.size != 1) {
+      val msg = s"save RPC failed (got ${result.size} results)"
+      logger.error(msg)
+      throw new RuntimeException(msg)
+    }
+
+    val strSavePath = result.values.head
+    logger.debug(s"srcFile: $strSavePath")
+
+    val dstDir = aModelPathPrefix.toUri().toString() match {
+      case fileRe(filepath) =>
+        val realpath = if (filepath.startsWith("/")) {
+          filepath
+        } else {
+          s"${(new java.io.File(".")).getAbsolutePath}/$filepath"
+        }
+        s"file://$realpath"
+    }
+    logger.debug(s"convert dstDir: $dstDir")
+
+    val localFileSystem = org.apache.hadoop.fs.FileSystem.getLocal(new Configuration())
+    val dstDirectory = localFileSystem.pathToFile(new org.apache.hadoop.fs.Path(dstDir))
+    val dstPath = new java.io.File(dstDirectory, aModelId)
+    val dstFile = new java.io.File(dstPath, "0.jubatus")
+    logger.debug(s"dstFile: $dstFile")
+
+    if (!dstPath.exists()) {
+      dstPath.mkdirs()
+    } else {
+      if (dstFile.exists()) {
+        dstFile.delete()
+      }
+    }
+
+    FileUtils.moveFile(new java.io.File(strSavePath), dstFile)
+    this
   }
 }

--- a/processor/src/test/scala/us/jubat/jubaql_server/processor/JubaQLServiceHelperSpec.scala
+++ b/processor/src/test/scala/us/jubat/jubaql_server/processor/JubaQLServiceHelperSpec.scala
@@ -18,6 +18,13 @@ package us.jubat.jubaql_server.processor
 import org.scalatest.{ShouldMatchers, BeforeAndAfterAll, FlatSpec}
 import org.scalatest.EitherValues._
 import org.apache.spark.SparkContext
+import org.apache.commons.io.FileExistsException
+import us.jubat.jubaql_server.processor.json.{JubaQLResponse, StatementProcessed}
+import us.jubat.yarn.common.LearningMachineType
+import us.jubat.yarn.client.JubatusYarnApplication
+
+import scala.util.Try
+
 
 /* This test case tests only the state-independent (helper) functions of
  * JubaQLService (such as `parseJson()` or `extractDatum()`). It does
@@ -29,11 +36,46 @@ import org.apache.spark.SparkContext
 class JubaQLServiceHelperSpec extends FlatSpec with ShouldMatchers with BeforeAndAfterAll {
   private var sc: SparkContext = null
   private var service: JubaQLServiceTester = null
+  private var proService: JubaQLServiceProductionTester = null
+
+  val throwExceptionName = "throwExceptionName"
 
   // create a subclass to test the protected methods
   class JubaQLServiceTester(sc: SparkContext) extends JubaQLService(sc, RunMode.Development, "file:///tmp/spark") {
     override def parseJson(in: String): Either[(Int, String), JubaQLAST] =
       super.parseJson(in)
+
+    override def takeAction(ast: JubaQLAST): Either[(Int, String), JubaQLResponse] =
+      super.takeAction(ast)
+  }
+
+  // create a subclass to test the protected methods for Production Mode
+  class JubaQLServiceProductionTester(sc: SparkContext, runMode: RunMode) extends JubaQLService(sc, runMode, "file:///tmp/spark") {
+    override def takeAction(ast: JubaQLAST): Either[(Int, String), JubaQLResponse] =
+      super.takeAction(ast)
+  }
+
+  // create a subclass to test the protected methods
+  class LocalJubatusApplicationTester(name: String) extends LocalJubatusApplication(null, name, LearningMachineType.Classifier, "jubaclassifier") {
+    override def saveModel(aModelPathPrefix: org.apache.hadoop.fs.Path, aModelId: String): Try[JubatusYarnApplication] = Try {
+      name match {
+        case throwExceptionName =>
+          throw new FileExistsException("exception for test")
+
+        case _ =>
+          this
+      }
+    }
+
+    override def loadModel(aModelPathPrefix: org.apache.hadoop.fs.Path, aModelId: String): Try[JubatusYarnApplication] = Try {
+      name match {
+        case throwExceptionName =>
+          throw new FileExistsException("exception for test")
+
+        case _ =>
+          this
+      }
+    }
   }
 
   "parseJson()" should "be able to parse JSON" taggedAs (LocalTest) in {
@@ -80,9 +122,266 @@ class JubaQLServiceHelperSpec extends FlatSpec with ShouldMatchers with BeforeAn
     result.left.value._1 shouldBe 400
   }
 
+  // SaveModel test
+  "takeAction():SaveModel" should "return an success for Development mode" taggedAs (LocalTest) in {
+    val parser = new JubaQLParser
+    val ast: JubaQLAST = new SaveModel("test", "file:///home/data/models", "test001")
+    val cm = new CreateModel("CLASSIFIER", "test", None, null, "")
+    val juba = new LocalJubatusApplicationTester("test")
+
+    service.models.put("test", (juba, cm, LearningMachineType.Classifier))
+    val result: Either[(Int, String), JubaQLResponse] = service.takeAction(ast)
+    service.models.remove("test")
+
+    val sp = result.right.value.asInstanceOf[StatementProcessed]
+    sp.result shouldBe "SAVE MODEL"
+  }
+
+  it should "return error of non model for Development mode" taggedAs (LocalTest) in {
+    val parser = new JubaQLParser
+    val ast: JubaQLAST = new SaveModel("test", "file:///home/data/models", "test001")
+    val juba = new LocalJubatusApplicationTester("test")
+
+    val result: Either[(Int, String), JubaQLResponse] = service.takeAction(ast)
+
+    result.left.value._1 shouldBe 400
+  }
+
+  it should "return error of invalid model path for Development mode" taggedAs (LocalTest) in {
+    val parser = new JubaQLParser
+    val ast: JubaQLAST = new SaveModel("test", "hdfs:///home/data/models", "test001")
+    val cm = new CreateModel("CLASSIFIER", "test", None, null, "")
+    val juba = new LocalJubatusApplicationTester("test")
+
+    service.models.put("test", (juba, cm, LearningMachineType.Classifier))
+    val result: Either[(Int, String), JubaQLResponse] = service.takeAction(ast)
+    service.models.remove("test")
+
+    result.left.value._1 shouldBe 400
+  }
+
+  it should "return error invalid model path2 for Development mode" taggedAs (LocalTest) in {
+    val parser = new JubaQLParser
+    val ast: JubaQLAST = new SaveModel("test", "file:/tmp/data/models", "test001")
+    val cm = new CreateModel("CLASSIFIER", "test", None, null, "")
+    val juba = new LocalJubatusApplicationTester("test")
+
+    service.models.put("test", (juba, cm, LearningMachineType.Classifier))
+    val result: Either[(Int, String), JubaQLResponse] = service.takeAction(ast)
+    service.models.remove("test")
+
+    result.left.value._1 shouldBe 400
+  }
+
+  it should "return error of saveModel method for Development mode" taggedAs (LocalTest) in {
+    val parser = new JubaQLParser
+    val ast: JubaQLAST = new SaveModel("test", "file:///home/data/models", "test001")
+    val cm = new CreateModel("CLASSIFIER", "test", None, null, "")
+    val juba = new LocalJubatusApplicationTester(throwExceptionName)
+
+    service.models.put("test", (juba, cm, LearningMachineType.Classifier))
+    val result: Either[(Int, String), JubaQLResponse] = service.takeAction(ast)
+    service.models.remove("test")
+
+    result.left.value._1 shouldBe 500
+  }
+
+  it should "return success for Production mode" taggedAs (LocalTest) in {
+    val parser = new JubaQLParser
+    val ast: JubaQLAST = new SaveModel("test", "hdfs:///home/data/models", "test001")
+    val cm = new CreateModel("CLASSIFIER", "test", None, null, "")
+    val juba = new LocalJubatusApplicationTester("test")
+
+    proService.models.put("test", (juba, cm, LearningMachineType.Classifier))
+    val result: Either[(Int, String), JubaQLResponse] = proService.takeAction(ast)
+    proService.models.remove("test")
+
+    val sp = result.right.value.asInstanceOf[StatementProcessed]
+    sp.result shouldBe "SAVE MODEL"
+  }
+
+  it should "return error of non model for Production mode" taggedAs (LocalTest) in {
+    val parser = new JubaQLParser
+    val ast: JubaQLAST = new SaveModel("test", "hdfs:///home/data/models", "test001")
+    val juba = new LocalJubatusApplicationTester("test")
+
+    val result: Either[(Int, String), JubaQLResponse] = proService.takeAction(ast)
+
+    result.left.value._1 shouldBe 400
+  }
+
+  it should "return error of invalid model path for Production mode" taggedAs (LocalTest) in {
+    val parser = new JubaQLParser
+    val ast: JubaQLAST = new SaveModel("test", "file:///home/data/models", "test001")
+    val cm = new CreateModel("CLASSIFIER", "test", None, null, "")
+    val juba = new LocalJubatusApplicationTester("test")
+
+    proService.models.put("test", (juba, cm, LearningMachineType.Classifier))
+    val result: Either[(Int, String), JubaQLResponse] = proService.takeAction(ast)
+    proService.models.remove("test")
+
+    result.left.value._1 shouldBe 400
+  }
+
+  it should "return error of invalid model path2 for Production mode" taggedAs (LocalTest) in {
+    val parser = new JubaQLParser
+    val ast: JubaQLAST = new SaveModel("test", "hdfs:/home/data/models", "test001")
+    val cm = new CreateModel("CLASSIFIER", "test", None, null, "")
+    val juba = new LocalJubatusApplicationTester("test")
+
+    proService.models.put("test", (juba, cm, LearningMachineType.Classifier))
+    val result: Either[(Int, String), JubaQLResponse] = proService.takeAction(ast)
+    proService.models.remove("test")
+
+    result.left.value._1 shouldBe 400
+  }
+
+  it should "return error of saveModel method for Production mode" taggedAs (LocalTest) in {
+    val parser = new JubaQLParser
+    val ast: JubaQLAST = new SaveModel("test", "hdfs:///home/data/models", "test001")
+    val cm = new CreateModel("CLASSIFIER", "test", None, null, "")
+    val juba = new LocalJubatusApplicationTester(throwExceptionName)
+
+    proService.models.put("test", (juba, cm, LearningMachineType.Classifier))
+    val result: Either[(Int, String), JubaQLResponse] = proService.takeAction(ast)
+    proService.models.remove("test")
+
+    result.left.value._1 shouldBe 500
+  }
+
+  // LoadModel test
+  "takeAction():LoadModel" should "return an success for Development mode" taggedAs (LocalTest) in {
+    val parser = new JubaQLParser
+    val ast: JubaQLAST = new LoadModel("test", "file:///home/data/models", "test001")
+    val cm = new CreateModel("CLASSIFIER", "test", None, null, "")
+    val juba = new LocalJubatusApplicationTester("test")
+
+    service.models.put("test", (juba, cm, LearningMachineType.Classifier))
+    val result: Either[(Int, String), JubaQLResponse] = service.takeAction(ast)
+    service.models.remove("test")
+
+    val sp = result.right.value.asInstanceOf[StatementProcessed]
+    sp.result shouldBe "LOAD MODEL"
+  }
+
+  it should "return error of non model for Development mode" taggedAs (LocalTest) in {
+    val parser = new JubaQLParser
+    val ast: JubaQLAST = new LoadModel("test", "file:///home/data/models", "test001")
+    val juba = new LocalJubatusApplicationTester("test")
+
+    val result: Either[(Int, String), JubaQLResponse] = service.takeAction(ast)
+
+    result.left.value._1 shouldBe 400
+  }
+
+  it should "return error of invalid model path for Development mode" taggedAs (LocalTest) in {
+    val parser = new JubaQLParser
+    val ast: JubaQLAST = new LoadModel("test", "hdfs:///home/data/models", "test001")
+    val cm = new CreateModel("CLASSIFIER", "test", None, null, "")
+    val juba = new LocalJubatusApplicationTester("test")
+
+    service.models.put("test", (juba, cm, LearningMachineType.Classifier))
+    val result: Either[(Int, String), JubaQLResponse] = service.takeAction(ast)
+    service.models.remove("test")
+
+    result.left.value._1 shouldBe 400
+  }
+
+  it should "return error invalid model path2 for Development mode" taggedAs (LocalTest) in {
+    val parser = new JubaQLParser
+    val ast: JubaQLAST = new LoadModel("test", "file:/tmp/data/models", "test001")
+    val cm = new CreateModel("CLASSIFIER", "test", None, null, "")
+    val juba = new LocalJubatusApplicationTester("test")
+
+    service.models.put("test", (juba, cm, LearningMachineType.Classifier))
+    val result: Either[(Int, String), JubaQLResponse] = service.takeAction(ast)
+    service.models.remove("test")
+
+    result.left.value._1 shouldBe 400
+  }
+
+  it should "return error of loadModel method for Development mode" taggedAs (LocalTest) in {
+    val parser = new JubaQLParser
+    val ast: JubaQLAST = new LoadModel("test", "file:///home/data/models", "test001")
+    val cm = new CreateModel("CLASSIFIER", "test", None, null, "")
+    val juba = new LocalJubatusApplicationTester(throwExceptionName)
+
+    service.models.put("test", (juba, cm, LearningMachineType.Classifier))
+    val result: Either[(Int, String), JubaQLResponse] = service.takeAction(ast)
+    service.models.remove("test")
+
+    result.left.value._1 shouldBe 500
+  }
+
+  it should "return success for Production mode" taggedAs (LocalTest) in {
+    val parser = new JubaQLParser
+    val ast: JubaQLAST = new LoadModel("test", "hdfs:///home/data/models", "test001")
+    val cm = new CreateModel("CLASSIFIER", "test", None, null, "")
+    val juba = new LocalJubatusApplicationTester("test")
+
+    proService.models.put("test", (juba, cm, LearningMachineType.Classifier))
+    val result: Either[(Int, String), JubaQLResponse] = proService.takeAction(ast)
+    proService.models.remove("test")
+
+    val sp = result.right.value.asInstanceOf[StatementProcessed]
+    sp.result shouldBe "LOAD MODEL"
+  }
+
+  it should "return error of non model for Production mode" taggedAs (LocalTest) in {
+    val parser = new JubaQLParser
+    val ast: JubaQLAST = new LoadModel("test", "hdfs:///home/data/models", "test001")
+    val juba = new LocalJubatusApplicationTester("test")
+
+    val result: Either[(Int, String), JubaQLResponse] = proService.takeAction(ast)
+
+    result.left.value._1 shouldBe 400
+  }
+
+  it should "return error of invalid model path for Production mode" taggedAs (LocalTest) in {
+    val parser = new JubaQLParser
+    val ast: JubaQLAST = new LoadModel("test", "file:///home/data/models", "test001")
+    val cm = new CreateModel("CLASSIFIER", "test", None, null, "")
+    val juba = new LocalJubatusApplicationTester("test")
+
+    proService.models.put("test", (juba, cm, LearningMachineType.Classifier))
+    val result: Either[(Int, String), JubaQLResponse] = proService.takeAction(ast)
+    proService.models.remove("test")
+
+    result.left.value._1 shouldBe 400
+  }
+
+  it should "return error of invalid model path2 for Production mode" taggedAs (LocalTest) in {
+    val parser = new JubaQLParser
+    val ast: JubaQLAST = new LoadModel("test", "hdfs:/home/data/models", "test001")
+    val cm = new CreateModel("CLASSIFIER", "test", None, null, "")
+    val juba = new LocalJubatusApplicationTester("test")
+
+    proService.models.put("test", (juba, cm, LearningMachineType.Classifier))
+    val result: Either[(Int, String), JubaQLResponse] = proService.takeAction(ast)
+    proService.models.remove("test")
+
+    result.left.value._1 shouldBe 400
+  }
+
+  it should "return error of loadModel method for Production mode" taggedAs (LocalTest) in {
+    val parser = new JubaQLParser
+    val ast: JubaQLAST = new LoadModel("test", "hdfs:///home/data/models", "test001")
+    val cm = new CreateModel("CLASSIFIER", "test", None, null, "")
+    val juba = new LocalJubatusApplicationTester(throwExceptionName)
+
+    proService.models.put("test", (juba, cm, LearningMachineType.Classifier))
+    val result: Either[(Int, String), JubaQLResponse] = proService.takeAction(ast)
+    proService.models.remove("test")
+
+    result.left.value._1 shouldBe 500
+  }
+
   override protected def beforeAll(): Unit = {
     sc = new SparkContext("local[3]", "JubaQL Processor Test")
     service = new JubaQLServiceTester(sc)
+
+    val hosts: List[(String, Int)] = List(("localhost", 1111))
+    proService = new JubaQLServiceProductionTester(sc, RunMode.Production(hosts))
   }
 
   override protected def afterAll(): Unit = {

--- a/processor/src/test/scala/us/jubat/jubaql_server/processor/LocalJubatusApplicationSpec.scala
+++ b/processor/src/test/scala/us/jubat/jubaql_server/processor/LocalJubatusApplicationSpec.scala
@@ -20,9 +20,15 @@ import us.jubat.yarn.common.LearningMachineType
 import scala.concurrent._
 import ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
-import scala.util.Success
+import scala.util.{Success, Failure}
+import org.apache.hadoop.fs.Path
+import org.apache.commons.io.FileUtils
+import org.apache.hadoop.conf.Configuration
+import java.net.InetSocketAddress
 
-class LocalJubatusApplicationSpec extends FlatSpec with ShouldMatchers {
+class LocalJubatusApplicationSpec extends FlatSpec with ShouldMatchers with BeforeAndAfterAll {
+
+  private var dummyJubaServer: DummyJubatusServer = null
 
   val anomalyConfig = """{
   "method" : "lof",
@@ -178,5 +184,472 @@ class LocalJubatusApplicationSpec extends FlatSpec with ShouldMatchers {
         Await.ready(app.stop(), Duration.Inf)
       case _ =>
     }
+  }
+
+  "saveModel" should "saveModel for classifier" taggedAs (LocalTest, JubatusTest) in {
+    val juba = new LocalJubatusApplication(null, "Test001", LearningMachineType.Classifier, "jubaclassifier", 9300)
+
+    val dstFile = new java.io.File("/tmp/t1/data/classifier/test001/0.jubatus")
+    if (dstFile.exists()) {
+      dstFile.delete()
+    }
+    val dstPath = new java.io.File("/tmp/t1/data/classifier/test001")
+    if (dstPath.exists()) {
+      dstPath.delete()
+    }
+
+    val modelPath = new Path("file:///tmp/t1/data/classifier")
+    val retApp = juba.saveModel(modelPath, "test001")
+
+    retApp shouldBe a[Success[_]]
+    dstFile.exists() shouldBe true
+  }
+
+  it should "saveModel a file doesn't exist for classifier" taggedAs (LocalTest, JubatusTest) in {
+    val juba = new LocalJubatusApplication(null, "Test002", LearningMachineType.Classifier, "jubaclassifier", 9300)
+
+    val dstFile = new java.io.File("/tmp/t1/data/classifier/test002/0.jubatus")
+    if (dstFile.exists()) {
+      dstFile.delete()
+    }
+    val dstPath = new java.io.File("/tmp/t1/data/classifier/test002")
+    if (!dstPath.exists()) {
+      dstPath.mkdirs()
+    }
+
+    val modelPath = new Path("file:///tmp/t1/data/classifier")
+    val retApp = juba.saveModel(modelPath, "test002")
+
+    retApp shouldBe a[Success[_]]
+    dstFile.exists() shouldBe true
+  }
+
+  it should "saveModel a file exists for classifier" taggedAs (LocalTest, JubatusTest) in {
+    val juba = new LocalJubatusApplication(null, "Test003", LearningMachineType.Classifier, "jubaclassifier", 9300)
+
+    val dstPath = new java.io.File("/tmp/t1/data/classifier/test003")
+    if (!dstPath.exists()) {
+      dstPath.mkdirs()
+    }
+
+    val dstFile = new java.io.File("/tmp/t1/data/classifier/test003/0.jubatus")
+    if (!dstFile.exists()) {
+      dstFile.createNewFile()
+    }
+
+    val writer = new java.io.FileWriter(dstFile, true)
+    writer.write("test")
+    writer.close()
+    val beforLen = dstFile.length()
+
+    val modelPath = new Path("file:///tmp/t1/data/classifier")
+    val retApp = juba.saveModel(modelPath, "test003")
+
+    retApp shouldBe a[Success[_]]
+    dstFile.exists() shouldBe true
+    dstFile.length() should not be beforLen
+  }
+
+  it should "saveModel no write permission for classifier" taggedAs (LocalTest, JubatusTest) in {
+    val juba = new LocalJubatusApplication(null, "Test004", LearningMachineType.Classifier, "jubaclassifier", 9300)
+
+    val dstPath = new java.io.File("/tmp/t1/data/classifier/test004")
+    if (!dstPath.exists()) {
+      dstPath.mkdirs()
+    }
+    val dstFile = new java.io.File("/tmp/t1/data/classifier/test004/0.jubatus")
+    if (dstFile.exists()) {
+      dstFile.delete()
+    }
+    dstPath.setReadOnly()
+
+    val modelPath = new Path("file:///t1/data/classifier")
+    val retApp = juba.saveModel(modelPath, "test004")
+
+    retApp should not be a[Success[_]]
+    dstFile.exists() shouldBe false
+  }
+
+  it should "saveModel relative path for classifier" taggedAs (LocalTest, JubatusTest) in {
+    saveModelForRelativePath("tmp/data/classifier", "test005")
+  }
+
+  it should "saveModel relative path2 for classifier" taggedAs (LocalTest, JubatusTest) in {
+    saveModelForRelativePath("./tmp/data/classifier", "test006")
+  }
+
+  it should "saveModel relative path3 for classifier" taggedAs (LocalTest, JubatusTest) in {
+    saveModelForRelativePath("../tmp/data/classifier", "test007")
+  }
+
+  it should "saveModel save RPC result.size is 0" taggedAs (LocalTest, JubatusTest) in {
+    val juba = new LocalJubatusApplication(null, dummyJubaServer.JubaServer.resultSize0, LearningMachineType.Classifier, "jubaclassifier", 9300)
+    val modelPath = new Path("file:///tmp/data/classifier")
+    val retApp = juba.saveModel(modelPath, "test001")
+
+    retApp shouldBe a[Failure[_]]
+
+    retApp match {
+      case Failure(t) =>
+        t.printStackTrace()
+
+      case Success(_) =>
+        printf("save model success")
+    }
+  }
+
+  it should "saveModel save RPC result.size is 2" taggedAs (LocalTest, JubatusTest) in {
+    val juba = new LocalJubatusApplication(null, dummyJubaServer.JubaServer.resultSize2, LearningMachineType.Classifier, "jubaclassifier", 9300)
+    val modelPath = new Path("file:///tmp/data/classifier")
+    val retApp = juba.saveModel(modelPath, "test001")
+
+    retApp shouldBe a[Failure[_]]
+
+    retApp match {
+      case Failure(t) =>
+        t.printStackTrace()
+
+      case Success(_) =>
+        printf("save model success")
+    }
+  }
+
+  private def saveModelForRelativePath(path: String, id: String) {
+    val juba = new LocalJubatusApplication(null, id, LearningMachineType.Classifier, "jubaclassifier", 9300)
+
+    val dstFile = new java.io.File(s"$path/$id/0.jubatus")
+    if (dstFile.exists()) {
+      dstFile.delete()
+    }
+
+    val df = new java.io.File(s"/tmp/data/classifier/$id/0.jubatus")
+    if (df.exists()) {
+      df.delete()
+    }
+
+    val modelPath = new Path(s"file://$path")
+    val retApp = juba.saveModel(modelPath, id)
+
+    retApp shouldBe a[Success[_]]
+    dstFile.exists() shouldBe true
+    df.exists() shouldBe false
+  }
+
+  "loadModel" should "loadModel for classifier" taggedAs (LocalTest, JubatusTest) in {
+    val juba = new LocalJubatusApplication(null, "Test001", LearningMachineType.Classifier, "jubaclassifier", 9300)
+
+    val srcPath = new java.io.File("/tmp/t1/data/classifier/test001")
+    if (!srcPath.exists()) {
+      srcPath.mkdirs()
+    }
+    val srcFile = new java.io.File("/tmp/t1/data/classifier/test001/0.jubatus")
+    if (!srcFile.exists()) {
+      srcFile.createNewFile()
+    }
+    val dstFile = new java.io.File("/tmp/dummyHost_port_classifier_test001.jubatus")
+    if (dstFile.exists()) {
+      dstFile.delete()
+    }
+
+    val modelPath = new Path("file:///tmp/t1/data/classifier")
+    val retApp = juba.loadModel(modelPath, "test001")
+
+    retApp shouldBe a[Success[_]]
+    srcFile.exists() shouldBe true
+    dstFile.exists() shouldBe true
+  }
+
+  it should "loadModel a dstFile exists for classifier" taggedAs (LocalTest, JubatusTest) in {
+    val juba = new LocalJubatusApplication(null, "Test002", LearningMachineType.Classifier, "jubaclassifier", 9300)
+
+    val srcPath = new java.io.File("/tmp/t1/data/classifier/test002")
+    if (!srcPath.exists()) {
+      srcPath.mkdirs()
+    }
+    val srcFile = new java.io.File("/tmp/t1/data/classifier/test002/0.jubatus")
+    if (!srcFile.exists()) {
+      srcFile.createNewFile()
+    }
+    val dstFile = new java.io.File("/tmp/dummyHost_port_classifier_test002.jubatus")
+    if (!dstFile.exists()) {
+      dstFile.createNewFile()
+    }
+    val writer = new java.io.FileWriter(dstFile, true)
+    writer.write("test")
+    writer.close()
+    val beforLen = dstFile.length()
+
+    val modelPath = new Path("file:///tmp/t1/data/classifier")
+    val retApp = juba.loadModel(modelPath, "test002")
+
+    retApp shouldBe a[Success[_]]
+    srcFile.exists() shouldBe true
+    dstFile.exists() shouldBe true
+    dstFile.length() should not be beforLen
+  }
+
+  it should "loadModel a srcFolder doesn't exists for classifier" taggedAs (LocalTest, JubatusTest) in {
+    val juba = new LocalJubatusApplication(null, "Test003", LearningMachineType.Classifier, "jubaclassifier", 9300)
+
+    val srcPath = new java.io.File("/tmp/t1/data/classifier/test003")
+    if (srcPath.exists()) {
+      FileUtils.cleanDirectory(srcPath)
+      srcPath.delete()
+    }
+
+    val modelPath = new Path("file:///tmp/t1/data/classifier")
+    val retApp = juba.loadModel(modelPath, "test003")
+
+    retApp shouldBe a[Failure[_]]
+    retApp match {
+      case Failure(t) =>
+        t.printStackTrace()
+      case Success(_) =>
+        printf("load model success")
+    }
+  }
+
+  it should "loadModel a srcFile doesn't exists for classifier" taggedAs (LocalTest, JubatusTest) in {
+    val juba = new LocalJubatusApplication(null, "Test004", LearningMachineType.Classifier, "jubaclassifier", 9300)
+
+    val srcPath = new java.io.File("/tmp/t1/data/classifier/test004")
+    if (!srcPath.exists()) {
+      srcPath.mkdirs()
+    }
+    val srcFile = new java.io.File("/tmp/t1/data/classifier/test004/0.jubatus")
+    if (srcFile.exists()) {
+      srcFile.delete()
+    }
+
+    val modelPath = new Path("file:///tmp/t1/data/classifier")
+    val retApp = juba.loadModel(modelPath, "test004")
+
+    retApp shouldBe a[Failure[_]]
+    retApp match {
+      case Failure(t) =>
+        t.printStackTrace()
+      case Success(_) =>
+        printf("load model success")
+    }
+  }
+
+  it should "loadModel relative path for classifier" taggedAs (LocalTest, JubatusTest) in {
+    loadModelForRelativePath("tmp/t1/data/classifier", "test005")
+  }
+
+  it should "loadModel relative path2 for classifier" taggedAs (LocalTest, JubatusTest) in {
+    loadModelForRelativePath("./tmp/t1/data/classifier", "test006")
+  }
+
+  it should "loadModel relative path3 for classifier" taggedAs (LocalTest, JubatusTest) in {
+    loadModelForRelativePath("../tmp/t1/data/classifier", "test007")
+  }
+
+  it should "loadModel getStatus RPC result.size is 0" taggedAs (LocalTest, JubatusTest) in {
+    val juba = new LocalJubatusApplication(null, "errTest001", LearningMachineType.Classifier, "jubaclassifier", 9300)
+    dummyJubaServer.statusType = dummyJubaServer.JubaServer.resultSize0
+
+    val srcPath = new java.io.File("/tmp/t1/data/classifier/test008")
+    if (!srcPath.exists()) {
+      srcPath.mkdirs()
+    }
+    val srcFile = new java.io.File("/tmp/t1/data/classifier/test008/0.jubatus")
+    if (!srcFile.exists()) {
+      srcFile.createNewFile()
+    }
+    val dstFile = new java.io.File("/tmp/dummyHost_port_classifier_test008.jubatus")
+    if (dstFile.exists()) {
+      dstFile.delete()
+    }
+
+    val modelPath = new Path("file:///tmp/t1/data/classifier")
+    val retApp = juba.loadModel(modelPath, "test008")
+
+    retApp shouldBe a[Failure[_]]
+    retApp match {
+      case Failure(t) =>
+        t.printStackTrace()
+      case Success(_) =>
+        printf("load model success")
+    }
+  }
+
+  it should "loadModel getStatus RPC result.size is 2" taggedAs (LocalTest, JubatusTest) in {
+    val juba = new LocalJubatusApplication(null, "errTest001", LearningMachineType.Classifier, "jubaclassifier", 9300)
+    dummyJubaServer.statusType = dummyJubaServer.JubaServer.resultSize2
+
+    val srcPath = new java.io.File("/tmp/t1/data/classifier/test008")
+    if (!srcPath.exists()) {
+      srcPath.mkdirs()
+    }
+    val srcFile = new java.io.File("/tmp/t1/data/classifier/test008/0.jubatus")
+    if (!srcFile.exists()) {
+      srcFile.createNewFile()
+    }
+    val dstFile = new java.io.File("/tmp/dummyHost_port_classifier_test008.jubatus")
+    if (dstFile.exists()) {
+      dstFile.delete()
+    }
+
+    val modelPath = new Path("file:///tmp/t1/data/classifier")
+    val retApp = juba.loadModel(modelPath, "test008")
+
+    retApp shouldBe a[Failure[_]]
+    retApp match {
+      case Failure(t) =>
+        t.printStackTrace()
+      case Success(_) =>
+        printf("load model success")
+    }
+  }
+
+  it should "loadModel load RPC result error" taggedAs (LocalTest, JubatusTest) in {
+    val juba = new LocalJubatusApplication(null, "Test001", LearningMachineType.Classifier, "jubaclassifier", 9300)
+    dummyJubaServer.statusType = dummyJubaServer.JubaServer.resultSize1
+
+    val srcPath = new java.io.File("/tmp/t1/data/classifier/test008")
+    if (!srcPath.exists()) {
+      srcPath.mkdirs()
+    }
+    val srcFile = new java.io.File("/tmp/t1/data/classifier/test008/0.jubatus")
+    if (!srcFile.exists()) {
+      srcFile.createNewFile()
+    }
+    val dstFile = new java.io.File("/tmp/dummyHost_port_classifier_test008.jubatus")
+    if (dstFile.exists()) {
+      dstFile.delete()
+    }
+
+    val modelPath = new Path("file:///tmp/t1/data/classifier")
+    val retApp = juba.loadModel(modelPath, "test008")
+
+    retApp shouldBe a[Failure[_]]
+    retApp match {
+      case Failure(t) =>
+        t.printStackTrace()
+      case Success(_) =>
+        printf("load model success")
+    }
+  }
+
+  private def loadModelForRelativePath(path: String, id: String) {
+    val juba = new LocalJubatusApplication(null, id, LearningMachineType.Classifier, "jubaclassifier", 9300)
+
+    val localFileSystem = org.apache.hadoop.fs.FileSystem.getLocal(new Configuration())
+    val srcDirectory = localFileSystem.pathToFile(new org.apache.hadoop.fs.Path(path))
+
+    val srcPath = new java.io.File(srcDirectory, id)
+    if (!srcPath.exists()) {
+      srcPath.mkdirs()
+    }
+    val srcFile = new java.io.File(srcPath, "0.jubatus")
+    if (!srcFile.exists()) {
+      srcFile.createNewFile()
+    }
+    val dstFile = new java.io.File(s"/tmp/dummyHost_port_classifier_$id.jubatus")
+    if (dstFile.exists()) {
+      dstFile.delete()
+    }
+    val df = new java.io.File(s"/tmp/t1/data/classifier/$id/0.jubatus")
+    if (df.exists()) {
+      df.delete()
+    }
+
+    val modelPath = new Path(s"file://$path")
+    val retApp = juba.loadModel(modelPath, id)
+
+    retApp shouldBe a[Success[_]]
+    srcFile.exists() shouldBe true
+    dstFile.exists() shouldBe true
+    df.exists() shouldBe false
+  }
+
+  override protected def beforeAll(): Unit = {
+    dummyJubaServer = new DummyJubatusServer
+    dummyJubaServer.start(9300)
+  }
+
+  override protected def afterAll(): Unit = {
+    dummyJubaServer.stop()
+  }
+
+}
+
+class DummyJubatusServer {
+  var server: org.msgpack.rpc.Server = null
+  var statusType: String = JubaServer.resultSize1
+
+  object JubaServer {
+    val resultSize0: String = "resultSize0"
+    val resultSize1: String = "resultSize1"
+    val resultSize2: String = "resultSize2"
+  }
+  class JubaServer {
+    def save(strId: String): java.util.Map[String, String] = {
+      var ret: java.util.Map[String, String] = new java.util.HashMap()
+
+      strId match {
+        case JubaServer.resultSize0 => // return 0
+          ret
+
+        case JubaServer.resultSize2 => // return 2
+          ret.put("key1", "value1")
+          ret.put("key2", "value2")
+          ret
+
+        case _ =>
+          val file = new java.io.File("/tmp/test.jubatus")
+          if (!file.exists()) {
+            file.createNewFile()
+          }
+          ret.put("key1", "/tmp/test.jubatus")
+          ret
+      }
+    }
+
+    def load(strId: String): Boolean = {
+
+      strId match {
+        case "errTest001" =>
+          false
+
+        case _ =>
+          true
+      }
+    }
+
+    def get_status(): java.util.Map[String, java.util.Map[String, String]] = {
+      var ret: java.util.Map[String, java.util.Map[String, String]] = new java.util.HashMap()
+      var ret2: java.util.Map[String, String] = new java.util.HashMap()
+      statusType match {
+        case JubaServer.resultSize0 =>
+          ret
+
+        case JubaServer.resultSize2 =>
+          ret2.put("datadir", "file:///tmp")
+          ret2.put("type", "classifier")
+          ret.put("key1", ret2)
+          ret.put("key2", ret2)
+          ret
+
+        case _ =>
+          ret2.put("datadir", "file:///tmp")
+          ret2.put("type", "classifier")
+          ret.put("dummyHost_port", ret2)
+          ret
+      }
+    }
+  }
+
+  def start(id: Int) {
+    server = new org.msgpack.rpc.Server()
+    server.serve(new JubaServer())
+    server.listen(new InetSocketAddress(id))
+    println("*** DummyJubatusServer start ***")
+  }
+
+  def stop() {
+    server.close()
+    println("*** DummyJubatusServer stop ***")
   }
 }

--- a/processor/src/test/scala/us/jubat/jubaql_server/processor/ProcessUtil.scala
+++ b/processor/src/test/scala/us/jubat/jubaql_server/processor/ProcessUtil.scala
@@ -3,10 +3,8 @@ package us.jubat.jubaql_server.processor
 import scala.sys.process.{Process, ProcessBuilder}
 
 object ProcessUtil {
-  /**
-   * Returns a ProcessBuilder with an environment variable for checkpointDir.
-   */
-  def commandToProcessBuilder(command: Seq[String]): ProcessBuilder = {
-    Process(command, None, "JAVA_OPTS" -> "-Djubaql.checkpointdir=file:///tmp/spark")
+
+  def commandToProcessBuilder(command: Seq[String], env: String = "-Djubaql.checkpointdir=file:///tmp/spark"): ProcessBuilder = {
+    Process(command, None, "JAVA_OPTS" -> env)
   }
 }


### PR DESCRIPTION
Currently failure of spark-submit command execution is not detected.
As a result, it may cause a issue that is hard to track down for operators.

This patch depends on #4, #5 and #7. I'll rebase later.
